### PR TITLE
Allow categories to be grouped

### DIFF
--- a/client/src/components/account/transaction-list.tsx
+++ b/client/src/components/account/transaction-list.tsx
@@ -169,6 +169,7 @@ export default function TransactionList(props: Props) {
       }
  
     <AddSelector open={ showAddCategory }
+        groupId='{ props.account.groupId }'
         transaction={ selectedTransaction }
         onCancel={ () => setShowAddCategory(false) }
         onConfirm={() => setShowAddCategory(false) }/>

--- a/client/src/components/account/transaction-summary.tsx
+++ b/client/src/components/account/transaction-summary.tsx
@@ -78,9 +78,10 @@ export default function TransactionSummaryList(props: Props) {
       </Paper>
 
       <AddSelector open={ showAddCategory }
-          transaction={ selectedTransaction }
-          onCancel={ () => setShowAddCategory(false) }
-          onConfirm={() => setShowAddCategory(false) }/>
+        groupId='{ props.account.groupId }'
+        transaction={ selectedTransaction }
+        onCancel={ () => setShowAddCategory(false) }
+        onConfirm={() => setShowAddCategory(false) }/>
     </>
   );
 };

--- a/client/src/components/categories/category-group-list.tsx
+++ b/client/src/components/categories/category-group-list.tsx
@@ -1,0 +1,171 @@
+import { useState } from 'react';
+
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Tooltip from '@mui/material/Tooltip';
+import { SxProps } from '@mui/material/styles';
+import DeleteIcon from '@mui/icons-material/DeleteOutline';
+import EditIcon from '@mui/icons-material/Edit';
+import Paper from '@mui/material/Paper';
+
+import { useMessageDispatch } from '../../contexts/messages/context';
+import { CategoryGroup } from "../../model/category.model";
+import CategoryService from '../../services/category.service';
+import ConfirmationDialog from '../dialogs/confirm-dialog';
+import EditCategoryGroup from './edit-category-group';
+
+const colhead: SxProps = {
+  fontWeight: 'bold'
+};
+
+const compactCell = {
+  paddingLeft: 0,
+  paddingRight: 0
+};
+
+interface Props {
+  elevation?: number;
+  groups: Array<CategoryGroup>;
+  onSelected?: (group: CategoryGroup) => void;
+  onDelete?: (group: CategoryGroup) => void;
+  onEdit?: (group: CategoryGroup) => void;
+  onAdd?: (group: CategoryGroup) => void;
+}
+
+export default function CategoryGroupList(props: Props) {
+  const showMessage = useMessageDispatch();
+
+  const [ selectedGroup, setSelectedGroup ] = useState<CategoryGroup|undefined>(undefined);
+  const [ deleteGroupDialogOpen, setDeleteGroupDialogOpen ] = useState<boolean>(false);
+  const [ editGroupDialogOpen, setEditGroupDialogOpen ] = useState<boolean>(false);
+
+  function editGroupConfirmed(group: CategoryGroup) {
+    if (group.id) {
+      CategoryService.updateGroup(group)
+        .then(group => {
+          showMessage({ type: 'add', level: 'success', text: `Category Group "${group.name}" updated successfully` });
+          setEditGroupDialogOpen(false);
+
+          props.onEdit && props.onEdit(group);
+          setSelectedGroup(group);
+        })
+        .catch(err => showMessage(err))
+    } else {
+      CategoryService.createGroup(group)
+        .then(group => {
+          showMessage({ type: 'add', level: 'success', text: `Category Group "${group.name}" added successfully`});
+          setEditGroupDialogOpen(false);
+
+          props.onAdd && props.onAdd(group);
+          setSelectedGroup(group);
+        })
+        .catch(err => showMessage(err))
+    }
+  }
+
+  function handleSelectClick(group: CategoryGroup) {
+    setSelectedGroup(group);
+    props.onSelected && props.onSelected(group);
+  }
+
+  function handleEditClick(group: CategoryGroup) {
+    if (props.onEdit) {
+      handleSelectClick(group);
+      setEditGroupDialogOpen(true);
+    }
+  }
+
+  function handleAddClick() {
+    if (props.onAdd) {
+      setSelectedGroup(undefined);
+      setEditGroupDialogOpen(true);
+    }
+  }
+
+  function handleDeleteClick(group: CategoryGroup) {
+    if (props.onDelete) {
+      setSelectedGroup(group);
+      setDeleteGroupDialogOpen(true);
+    }
+  }
+
+  function onDeleteConfirmed() {
+    setDeleteGroupDialogOpen(false);
+
+    var group = selectedGroup
+    if (group !== undefined) {
+      CategoryService.deleteGroup(group.id!!)
+        .then(() => props.onDelete && props.onDelete(group!!))
+        .catch(err => showMessage(err))
+    }
+  }
+
+  return (
+    <Paper elevation={props.elevation || 0} sx={{ padding: 1}}>
+      <TableContainer>
+        <Table size='small'>
+          <TableHead>
+            <TableRow>
+              <TableCell sx={colhead}>Group</TableCell>
+              <TableCell sx={colhead}>Description</TableCell>
+              { props.onEdit &&
+                <TableCell sx={{ ...colhead, ...compactCell}} width="24px"></TableCell>
+              }
+              { props.onDelete &&
+                <TableCell sx={{ ...colhead, ...compactCell}} width="24px"></TableCell>
+              }
+            </TableRow>
+          </TableHead>
+
+          <TableBody>
+            { props.groups && props.groups
+              .sort((a, b) => a.name < b.name ? -1 : 1)
+              .map(group =>
+                <TableRow key={ group.id } hover selected={ selectedGroup && group.id === selectedGroup.id }>
+                  <TableCell onClick={() => handleSelectClick(group)}>{ group.name }</TableCell>
+                  <TableCell onClick={() => handleSelectClick(group)}>{ group.description }</TableCell>
+                  { props.onEdit &&
+                    <TableCell onClick={() => handleEditClick(group)} sx={ compactCell } width="24px">
+                      <Tooltip title="Edit category group..."><EditIcon/></Tooltip>
+                    </TableCell>
+                  }
+                  { props.onDelete &&
+                    <TableCell onClick={() => handleDeleteClick(group)} sx={ compactCell } width="24px">
+                      <Tooltip title="Delete category group..."><DeleteIcon/></Tooltip>
+                    </TableCell>
+                  }
+                </TableRow>
+              )
+            }
+            { props.onAdd &&
+            <>
+              <TableRow key={ "add1" }>
+                <TableCell align="center" colSpan={ 3 + (props.onDelete ? 1 : 0) + (props.onEdit ? 1 : 0) } />
+              </TableRow>
+              <TableRow key={ "add2" } hover>
+                <TableCell align="center" colSpan={ 3 + (props.onDelete ? 1 : 0) + (props.onEdit ? 1 : 0) }
+                  onClick={() => handleAddClick()}><b>Add Category Group...</b></TableCell>
+              </TableRow>
+              </>
+            }
+         </TableBody>
+        </Table>
+      </TableContainer>
+
+      <EditCategoryGroup open={ editGroupDialogOpen }
+        group={ selectedGroup }
+        onConfirm={ editGroupConfirmed }
+        onCancel={() => setEditGroupDialogOpen(false)}/>
+
+      <ConfirmationDialog open={ deleteGroupDialogOpen }
+        title={"Delete Category Group \""+ selectedGroup?.name + "\""}
+        content="Are you sure you want to delete this category?"
+        onConfirm={ onDeleteConfirmed }
+        onCancel={() => setDeleteGroupDialogOpen(false)} />
+   </Paper>
+  );
+}

--- a/client/src/components/categories/category-transactions.tsx
+++ b/client/src/components/categories/category-transactions.tsx
@@ -33,7 +33,7 @@ export default function CategoryTransactions(props: Props) {
   const [showAddCategory, setShowAddCategory] = useState<boolean>(false);
 
   useEffect(() => {
-    AccountService.getTransactionsByCategory(props.category.categoryId!!, props.fromDate, props.toDate)
+    AccountService.getTransactionsByCategory(props.category.groupId, props.category.categoryId!!, props.fromDate, props.toDate)
       .then(response => setTransactions(response))
       .catch(err => {
         setTransactions([]);
@@ -55,11 +55,11 @@ export default function CategoryTransactions(props: Props) {
   return(
     <>
       <Paper sx={{ margin: 1, padding: 2 }} elevation={3}>
-        <Box sx={{ textAlign: 'center', fontSize: '1.2em', fontWeight: 'bold' }}>{ props.category.category }</Box>
+        <Box sx={{ textAlign: 'center', fontSize: '1.2em', fontWeight: 'bold' }}>{ props.category.categoryName }</Box>
         <Table size="small" aria-label="transactions">
           <caption><i>
             { noTransactions ? 'there are no' : transactions.length } {' '}
-             transaction(s) matching "{props.category.category}"
+             transaction(s) matching "{props.category.categoryName}"
              from {toLocaleDate(props.fromDate)} (inclusive)
              to {toLocaleDate(props.toDate)} (exclusive)
           </i></caption>
@@ -85,6 +85,7 @@ export default function CategoryTransactions(props: Props) {
       </Paper>
 
       <AddSelector open={ showAddCategory }
+          groupId={ props.category.groupId }
           catagoryId={ props.category.categoryId }
           transaction={ selectedTransaction }
           onCancel={ () => closeAddToCategory() }

--- a/client/src/components/categories/edit-category-group.tsx
+++ b/client/src/components/categories/edit-category-group.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useState } from "react";
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle, TextField } from "@mui/material";
+
+import { CategoryGroup } from "../../model/category.model";
+
+interface Props {
+  open: boolean;
+  group: CategoryGroup | undefined;
+  onConfirm: (group: CategoryGroup) => void;
+  onCancel: () => void;
+}
+
+export default function EditCategoryGroup(props: Props) {
+  const handleCancel = () => {
+    props.onCancel();
+  };
+
+  function handleConfirm() {
+    props.onConfirm(group);
+  };
+
+  const [ group, setGroup ] = useState<CategoryGroup>({ name: "" });
+  useEffect(() => { setGroup(props.group || { name: "", description: "" }) }, [ props ]);
+
+  function validateForm(): boolean {
+    return group.name.trim().length > 0;
+  }
+
+  return (
+    <Dialog open={ props.open } onClose={ handleCancel } fullWidth>
+      <DialogTitle sx={{ bgcolor: 'primary.main', color: 'white'}}>{ props.group ? "Edit Category Group" : "Add Category Group" }</DialogTitle>
+      <DialogContent>
+        <p/>
+        <TextField
+          id="name" label="Group Name" autoFocus required
+          margin="normal" fullWidth variant="standard"
+          value={group.name}
+          onChange={(e) => setGroup({ ...group, name: e.target.value })}
+        />
+
+        <TextField
+          id="name" label="Description"
+          margin="normal" fullWidth variant="standard"
+          value={group.description}
+          onChange={(e) => setGroup({ ...group, description: e.target.value })}
+        />
+      </DialogContent>
+
+      <DialogActions>
+        <Button onClick={handleCancel} variant="outlined">Cancel</Button>
+        <Button onClick={handleConfirm} variant="contained" disabled={!validateForm()}>
+          { props.group ? "Save" : "Add" }
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/client/src/components/categories/edit-category.tsx
+++ b/client/src/components/categories/edit-category.tsx
@@ -2,10 +2,11 @@ import { useEffect, useState } from "react";
 import { Button, Dialog, DialogActions, DialogContent, DialogTitle, TextField } from "@mui/material";
 import { MuiColorInput } from 'mui-color-input'
 
-import { Category } from "../../model/category.model";
+import { CategoryGroup, Category } from "../../model/category.model";
 
 interface Props {
   open: boolean;
+  group: CategoryGroup;
   category: Category | undefined;
   onConfirm: (category: Category) => void;
   onCancel: () => void;
@@ -32,6 +33,12 @@ export default function EditCategory(props: Props) {
       <DialogTitle sx={{ bgcolor: 'primary.main', color: 'white'}}>{ props.category ? "Edit Category" : "Add Category" }</DialogTitle>
       <DialogContent>
         <p/>
+        <TextField
+          id="group" label="Group"
+          margin="normal" fullWidth variant="standard"
+          value={props.group.name} disabled
+        />
+
         <TextField
           id="name" label="Category Name" autoFocus required
           margin="normal" fullWidth variant="standard"

--- a/client/src/components/graph/statistics-graph.tsx
+++ b/client/src/components/graph/statistics-graph.tsx
@@ -5,6 +5,7 @@ import Grid from '@mui/material/Grid';
 import Stack from '@mui/material/Stack';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Switch from '@mui/material/Switch';
+import { FormControl, InputLabel, MenuItem, Select } from '@mui/material';
 import { PieChart } from '@mui/x-charts/PieChart';
 import { PieValueType } from '@mui/x-charts/models/seriesType/pie';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
@@ -15,7 +16,7 @@ import 'dayjs/locale/en-gb';
 
 import { useMessageDispatch } from '../../contexts/messages/context';
 import CategoryService from '../../services/category.service';
-import { CategoryStatistics } from '../../model/category.model';
+import { CategoryGroup, CategoryStatistics } from '../../model/category.model';
 
 var debounce = require('lodash/debounce');
 
@@ -31,7 +32,7 @@ function toPieSlice(stat: CategoryStatistics, value: number): PieValueType {
   const p: PieValueType = {
     id: stat.categoryId || '',
     value: value,
-    label: stat.category,
+    label: stat.categoryName,
     color: stat.colour
   };
   return p;
@@ -39,6 +40,8 @@ function toPieSlice(stat: CategoryStatistics, value: number): PieValueType {
 
 export default function StatisticsGraph(props: Props) {
   const showMessage = useMessageDispatch();
+  const [ categoryGroups, setCategoryGroups ] = useState<CategoryGroup[]>([]);
+  const [ selectedGroup, setSelectedGroup ] = useState<CategoryGroup>();
   const [ statistics, setStatistics ] = useState<CategoryStatisticsUI[]>([]);
 
   // allows the previous statistics to be accessed in the useEffect hook
@@ -47,10 +50,18 @@ export default function StatisticsGraph(props: Props) {
 
   const [ dateRange, setDateRange ] = useState<Dayjs[]>([ dayjs().subtract(1, 'month'), dayjs().add(1, 'day') ]);
   const debouncedSetDateRange = debounce((value: Dayjs[]) => { setDateRange(value) }, 600);
-    
+
   useEffect(() => {
+    CategoryService.fetchAllGroups().then(response => setCategoryGroups(response))
+  }, []);
+
+  useEffect(() => {
+    if (selectedGroup === undefined) {
+      return;
+    }
+    
     if (dateRange[0] < dateRange[1]) {
-      CategoryService.getCategoryStatistics(dateRange[0].toDate(), dateRange[1].toDate())
+      CategoryService.getCategoryStatistics(selectedGroup.id!!, dateRange[0].toDate(), dateRange[1].toDate())
         .then(response => {
           const newStats = response.map(s => {
             // reflect the previous selection state in the new statistics
@@ -60,23 +71,32 @@ export default function StatisticsGraph(props: Props) {
           });
           setStatistics(newStats);
         })
-        .catch(err => showMessage(err));
+        .catch(err => 
+          showMessage(err)
+        );
     } else {
       showMessage({ type: 'add', level: 'info', text: 'The "from" date must be before the "to" date.' });
     }
-  }, [ showMessage, dateRange ]);
+  }, [ showMessage, selectedGroup, dateRange ]);
+
+  function selectGroup(event: any) {
+    const groupId = event.target.value;
+    setSelectedGroup(categoryGroups.find(group => group.id === groupId));
+  }
 
   // seriesData is an array of two arrays, the first for credit totals and the second for debit.
-  const seriesData = useMemo<Array<Array<PieValueType>>>(() => statistics
-    .filter(stat => stat.selected)
-    .map(stat => toPieSlice(stat, stat.total))
-    .reduce((acc, slice) => {
-      const index = slice.value > 0 ? 0 : 1;
-      slice.value = Math.abs(slice.value);
-      acc[index].push(slice);
+  const seriesData = useMemo<Array<Array<PieValueType>>>(() =>
+    statistics
+      .filter(stat => stat.selected)
+      .map(stat => toPieSlice(stat, stat.total))
+      .reduce((acc, slice) => {
+        const index = slice.value > 0 ? 0 : 1;
+        slice.value = Math.abs(slice.value);
+        acc[index].push(slice);
 
-      return acc;
-    }, Array.of([], []) as Array<Array<PieValueType>>), [ statistics ]);
+        return acc;
+      }, Array.of([], []) as Array<Array<PieValueType>>
+  ), [ statistics ]);
 
   function selectCategory(selectedSeries: number, selectedIndex: number) {
     var categoryId: string | undefined = seriesData[selectedSeries][selectedIndex].id as string;
@@ -100,21 +120,33 @@ export default function StatisticsGraph(props: Props) {
   return (
     <LocalizationProvider dateAdapter={ AdapterDayjs } adapterLocale={ 'en-gb' }>
       <Paper sx={{ margin: 1, padding: 2 }} elevation={3}>
-        <Grid container spacing={7} alignItems={"center"} justifyContent={"center"}>
-          <Grid key={1} item>
-            <DatePicker disableFuture label="From Date (inclusive)" value={ dayjs(dateRange[0]) }
-              onChange={ (value: any, context: any) => {
-                if (value != null && context.validationError == null)
-                  debouncedSetDateRange([ value, dateRange[1] ])
-                }}/>
+        <Grid container direction="column" rowGap={3} alignItems={"stretch"}>
+          <Grid container direction="row" justifyContent={"center"}>
+            <FormControl fullWidth>
+              <InputLabel id="select-group">Category Group</InputLabel>
+              <Select labelId="select-group" label="Category Group" value={ selectedGroup?.id || "" } onChange={ selectGroup }>
+                { categoryGroups.map(group =>
+                  <MenuItem key={ group.id } value={ group.id }>{ group.name }</MenuItem>
+                )}
+              </Select>
+            </FormControl>
           </Grid>
 
-          <Grid key={2} item>
-            <DatePicker maxDate={ dayjs().add(1, 'day') } label="To Date (exclusive)" value={ dayjs(dateRange[1]) }
-              onChange={ (value: any, context: any) => {
-                if (value != null && context.validationError == null)
-                  debouncedSetDateRange([ dateRange[0], value ])
-                }}/>
+          <Grid container direction="row" columnGap={7} justifyContent={"center"}>
+            <Grid key={2} item>
+              <DatePicker disableFuture label="From Date (inclusive)" value={ dayjs(dateRange[0]) }
+                onChange={ (value: any, context: any) => {
+                  if (value != null && context.validationError == null)
+                    debouncedSetDateRange([ value, dateRange[1] ])
+                  }}/>
+            </Grid>
+            <Grid key={3} item>
+              <DatePicker maxDate={ dayjs().add(1, 'day') } label="To Date (exclusive)" value={ dayjs(dateRange[1]) }
+                onChange={ (value: any, context: any) => {
+                  if (value != null && context.validationError == null)
+                    debouncedSetDateRange([ dateRange[0], value ])
+                  }}/>
+            </Grid>
           </Grid>
         </Grid>
       </Paper>
@@ -145,9 +177,9 @@ export default function StatisticsGraph(props: Props) {
           <Grid item>
             <Stack margin={ 2 }>
               { statistics.map(stat =>
-                <FormControlLabel key={ stat.category } label={ stat.category }
+                <FormControlLabel key={ stat.categoryName } label={ stat.categoryName }
                   control= {
-                    <Switch key={ stat.category } name={ stat.category } checked={ stat.selected }
+                    <Switch key={ stat.categoryName } name={ stat.categoryName } checked={ stat.selected }
                       style={{ color: stat.selected ? stat.colour : undefined }}
                       onChange={ e => toggleCategory(stat.categoryId, e.target.checked) }/>
                   }

--- a/client/src/model/category.model.ts
+++ b/client/src/model/category.model.ts
@@ -1,5 +1,12 @@
+export interface CategoryGroup {
+  id?: string;
+  name: string;
+  description?: string;
+}
+
 export interface Category {
   id?: string;
+  groupId?: string;
   name: string;
   description?: string;
   colour?: string;
@@ -12,8 +19,10 @@ export interface CategorySelector {
 }
 
 export interface CategoryStatistics {
-  categoryId?: string
-  category: string;
+  groupId: string;
+  groupName: string;
+  categoryId?: string;
+  categoryName: string;
   description?: string;
   colour: string;
   count: number;

--- a/client/src/pages/categories.tsx
+++ b/client/src/pages/categories.tsx
@@ -1,10 +1,87 @@
+import { useEffect, useState } from "react";
+import Grid from "@mui/material/Grid";
+
 import PageHeader from "../components/page-header/page-header";
+import CategoryGroupList from "../components/categories/category-group-list";
 import CategoryList from "../components/categories/category-list";
+import { CategoryGroup, Category } from "../model/category.model";
+import CategoryService from "../services/category.service";
 
 export default function Categories() {
+  const [ groups, setGroups ] = useState<Array<CategoryGroup>>([]);
+  const [ selectedGroup, selectGroup ] = useState<CategoryGroup|undefined>(undefined);
+  const [ categories, setCategories ] = useState<Array<Category>>([]);
+
+  useEffect(() => {
+    CategoryService.fetchAllGroups().then(response => setGroups(response));
+  }, [ ]);
+
+  useEffect(() => {
+    if (selectedGroup) {
+      CategoryService.fetchAllCategories(selectedGroup.id!!)
+        .then( response => setCategories(response));
+    }
+  }, [ selectedGroup ]);
+
+  function deleteGroup(group: CategoryGroup) {
+    selectGroup(undefined);
+    setGroups(groups.filter(c => c.id !== group.id));
+  }
+
+  function editGroup(group: CategoryGroup) {
+    setGroups(groups
+      .filter(g => g.id !== group.id)
+      .concat(group)
+      .sort((a, b) => a.name.localeCompare(b.name))
+    );
+    selectGroup(group);
+  }
+
+  function addGroup(group: CategoryGroup) {
+    setGroups(groups
+      .concat(group)
+      .sort((a, b) => a.name.localeCompare(b.name))
+    );
+    selectGroup(group);
+  }
+
+  function deleteCategory(category: Category) {
+    setCategories(categories.filter(c => c.id !== category.id));
+  }
+
+  function editCategory(category: Category) {
+    setCategories(categories
+      .filter(c => c.id !== category.id)
+      .concat(category)
+      .sort((a, b) => a.name.localeCompare(b.name))
+    );
+  }
+
+  function addCategory(category: Category) {
+    setCategories(categories
+      .concat(category)
+      .sort((a, b) => a.name.localeCompare(b.name))
+    );
+  }
+
   return (
-    <PageHeader title="Transaction Categories">
-      <CategoryList/>
+    <PageHeader title="Transaction Category Groups">
+      <Grid container direction="row" wrap="nowrap" width="100%" columnGap={2}>
+        <Grid item width="49%">
+          <CategoryGroupList elevation={ 3 }
+            groups={ groups }
+            onSelected={ selectGroup }
+            onAdd={ addGroup }
+            onEdit={ editGroup }
+            onDelete={ deleteGroup }/>
+        </Grid>
+        <Grid item width="49%">
+          <CategoryList elevation={ 3 } group={ selectedGroup } categories={ categories }
+            onAdd={ addCategory }
+            onEdit={ editCategory }
+            onDelete={ deleteCategory }/>
+        </Grid>
+      </Grid>
     </PageHeader>
   );
 }

--- a/client/src/services/account.service.ts
+++ b/client/src/services/account.service.ts
@@ -42,12 +42,12 @@ class AccountService {
     return transactions.reverse();
   }
 
-  getTransactionsByCategory(categoryId: string | undefined, fromDate: Date, toDate: Date): Promise<Array<TransactionDetail>> {
+  getTransactionsByCategory(groupId: string, categoryId: string | undefined, fromDate: Date, toDate: Date): Promise<Array<TransactionDetail>> {
     const fromDateStr = fromDate.toISOString().substring(0, 10);
     const toDateStr = toDate.toISOString().substring(0, 10);
     console.log(`Retrieving transactions by category [categoryId: ${categoryId}, from-date: ${fromDateStr}, to-date: ${toDateStr}]`);
 
-    return http.get<Array<TransactionDetail>>(`/rails/transactions/category`,
+    return http.get<Array<TransactionDetail>>(`/rails/transactions/${groupId}/category`,
       { params: { "category-id": categoryId, "from-date": fromDateStr, "to-date": toDateStr }})
       .then(response => response.data);
   }

--- a/client/src/services/category.service.ts
+++ b/client/src/services/category.service.ts
@@ -1,34 +1,74 @@
 import http from './http-common';
 import PaginatedList from '../model/paginated-list.model';
-import { Category, CategorySelector, CategoryStatistics } from '../model/category.model';
+import { CategoryGroup, Category, CategorySelector, CategoryStatistics } from '../model/category.model';
 
 class CategoryService {
-  getPage(page: number = 0, pageSize: number = 1000): Promise<PaginatedList<Category>> {
-    console.log(`Retrieving categories [page: ${page}, pageSize: ${pageSize}]`);
-    return http.get<PaginatedList<Category>>('/rails/categories', { params: { "page": page, "page-size": pageSize }})
+  getGroupsPage(page: number = 0, pageSize: number = 20): Promise<PaginatedList<CategoryGroup>> {
+    console.log(`Retrieving groups [page: ${page}, pageSize: ${pageSize}]`);
+    return http.get<PaginatedList<CategoryGroup>>('/rails/category-groups', { params: { "page": page, "page-size": pageSize }})
       .then(response => response.data);
   }
 
-  async fetchAllCategories(): Promise<Array<Category>> {
+  async fetchAllGroups(): Promise<Array<CategoryGroup>> {
+    console.log('Retrieving ALL category groups');
+    var response = await this.getGroupsPage(0, 100);
+    var groups = response.items as Array<CategoryGroup>;
+    while (response.links.next) {
+      response = await this.getGroupsPage(response.page + 1, 100);
+      groups = groups.concat(response.items);
+    }
+    return groups;
+  }
+
+  getGroup(groupId: string): Promise<CategoryGroup> {
+    console.log(`Retrieving group [id: ${groupId}]`);
+    return http.get<CategoryGroup>(`/rails/category-groups/${groupId}`)
+      .then(response => response.data);
+  }
+
+  createGroup(group: CategoryGroup): Promise<CategoryGroup> {
+    console.log(`Creating group [name: ${group.name}]`);
+    return http.post<CategoryGroup>('/rails/category-groups', group)
+      .then(response => response.data);
+  }
+
+  updateGroup(group: CategoryGroup): Promise<CategoryGroup> {
+    console.log(`Updating group [id: ${group.id}, name: ${group.name}]`);
+    return http.put<CategoryGroup>(`/rails/category-groups/${group.id}`, group)
+      .then(response => response.data);
+  }
+
+  deleteGroup(groupId: string): Promise<any> {
+    console.log(`Deleting group [id: ${groupId}]`);
+    return http.delete<void>(`/rails/category-groups/${groupId}`);
+  }
+
+  getCategoriesPage(groupId: string, page: number = 0, pageSize: number = 20): Promise<PaginatedList<Category>> {
+    console.log(`Retrieving categories [group: ${groupId}, page: ${page}, pageSize: ${pageSize}]`);
+    return http.get<PaginatedList<Category>>(`/rails/category-groups/${groupId}/categories`, { params: { "page": page, "page-size": pageSize }})
+      .then(response => response.data);
+  }
+
+  async fetchAllCategories(groupId: string): Promise<Array<Category>> {
     console.log('Retrieving ALL categories');
-    var response = await this.getPage(0, 100);
+    var response = await this.getCategoriesPage(groupId, 0, 100);
     var categories = response.items as Array<Category>;
     while (response.links.next) {
-      response = await this.getPage(response.page + 1, 100);
+      response = await this.getCategoriesPage(groupId, response.page + 1, 100);
       categories = categories.concat(response.items);
     }
     return categories;
   }
 
-  get(categoryId: string): Promise<Category> {
+  getCategory(categoryId: string): Promise<Category> {
     console.log(`Retrieving category [id: ${categoryId}]`);
     return http.get<Category>(`/rails/categories/${categoryId}`)
       .then(response => response.data);
   }
 
-  createCategory(category: Category): Promise<Category> {
-    console.log(`Creating category [name: ${category.name}]`);
-    return http.post<Category>('/rails/categories', category)
+  createCategory(groupId: string, category: Category): Promise<Category> {
+    console.log(`Creating category [groupId: ${groupId}, name: ${category.name}]`);
+    return http.post<Category>(`/rails/category-groups/${groupId}/categories`, category)
       .then(response => response.data);
   }
 
@@ -56,11 +96,11 @@ class CategoryService {
       .then(response => response.data);
   }
 
-  getCategoryStatistics(fromDate: Date, toDate: Date): Promise<Array<CategoryStatistics>> {
+  getCategoryStatistics(groupId: string, fromDate: Date, toDate: Date): Promise<Array<CategoryStatistics>> {
     const fromDateStr = fromDate.toISOString().substring(0, 10);
     const toDateStr = toDate.toISOString().substring(0, 10);
-    console.log(`Retrieving category statistics [from: ${fromDateStr}, to: ${toDateStr}]`);
-    return http.get<Array<CategoryStatistics>>('/rails/categories/statistics',
+    console.log(`Retrieving category statistics [group: ${groupId}, from: ${fromDateStr}, to: ${toDateStr}]`);
+    return http.get<Array<CategoryStatistics>>(`/rails/category-groups/${groupId}/statistics`,
       { params: { "from-date": fromDateStr, "to-date": toDateStr }})
       .then(response => response.data);
   }

--- a/client/src/services/consent.service.ts
+++ b/client/src/services/consent.service.ts
@@ -20,7 +20,10 @@ class UserConsentService {
       callbackUri: window.location.origin + "/accounts"
     }
     return http.post(`/rails/consents/${institutionId}`, body)
-      .then(response => response.data);
+      .then(response => {
+        const location = response.headers["location"];
+        return location as Location;
+    });
   }
 
   cancelConsent(institutionId: string, purge: boolean = false) {

--- a/client/src/services/consent.service.ts
+++ b/client/src/services/consent.service.ts
@@ -20,10 +20,7 @@ class UserConsentService {
       callbackUri: window.location.origin + "/accounts"
     }
     return http.post(`/rails/consents/${institutionId}`, body)
-      .then(response => {
-        const location = response.headers["location"];
-        return location as Location;
-    });
+      .then(response => response.headers["location"] as Location);
   }
 
   cancelConsent(institutionId: string, purge: boolean = false) {

--- a/integration-module/integration-tests/src/main/java/com/hillayes/integration/api/AccountTransactionsApi.java
+++ b/integration-module/integration-tests/src/main/java/com/hillayes/integration/api/AccountTransactionsApi.java
@@ -2,13 +2,18 @@ package com.hillayes.integration.api;
 
 import com.hillayes.onestop.api.PaginatedTransactions;
 import com.hillayes.onestop.api.TransactionResponse;
+import io.restassured.common.mapper.TypeRef;
 
+import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
 import static io.restassured.http.ContentType.JSON;
 
 public class AccountTransactionsApi extends ApiBase {
+    private static final TypeRef<List<TransactionResponse>> TRANSACTION_LIST = new TypeRef<>() {};
+
     public AccountTransactionsApi(Map<String, String> authCookies) {
         super(authCookies);
     }
@@ -36,5 +41,29 @@ public class AccountTransactionsApi extends ApiBase {
             .statusCode(200)
             .contentType(JSON)
             .extract().as(TransactionResponse.class);
+    }
+
+    /**
+     * Returns the authenticated user's transactions filtered by the identified category;
+     * ordered by booking-datetime, descending.
+     * If the given categoryId is null, then the un-categorised transactions are for
+     * the identified category group returned.
+     *
+     * @param groupId the category group identifier.
+     * @param categoryId the category identifier.
+     * @param startDate the start date of the transactions (inclusive).
+     * @param endDate the end date of the transactions (exclusive).
+     * @return the transactions for the identified category.
+     */
+    public List<TransactionResponse> getTransactionsByCategory(UUID groupId, UUID categoryId,
+                                                               Instant startDate, Instant endDate) {
+        return givenAuth()
+            .queryParam("categoryId", categoryId)
+            .queryParam("startDate", startDate)
+            .queryParam("endDate", endDate)
+            .get("/api/v1/rails/transactions/{groupId}/category", groupId)
+            .then()
+            .statusCode(200)
+            .extract().as(TRANSACTION_LIST);
     }
 }

--- a/integration-module/integration-tests/src/main/java/com/hillayes/integration/api/CategoryApi.java
+++ b/integration-module/integration-tests/src/main/java/com/hillayes/integration/api/CategoryApi.java
@@ -1,0 +1,193 @@
+package com.hillayes.integration.api;
+
+import com.hillayes.nordigen.model.EndUserAgreement;
+import com.hillayes.nordigen.model.PaginatedList;
+import com.hillayes.onestop.api.*;
+import io.restassured.common.mapper.TypeRef;
+import io.restassured.response.Response;
+
+import java.net.URI;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static io.restassured.http.ContentType.JSON;
+
+public class CategoryApi extends ApiBase {
+    private static final TypeRef<List<AccountCategorySelector>> SELECTORS_LIST = new TypeRef<>() {};
+
+    public CategoryApi(Map<String, String> authCookies) {
+        super(authCookies);
+    }
+
+    public PaginatedCategoryGroups getCategoryGroups(int pageIndex, int pageSize) {
+        return givenAuth()
+            .queryParam("page", pageIndex)
+            .queryParam("page-size", pageSize)
+            .get("/api/v1/rails/category-groups")
+            .then()
+            .statusCode(200)
+            .contentType(JSON)
+            .extract().as(PaginatedCategoryGroups.class);
+    }
+
+    public CategoryGroupResponse getCategoryGroup(UUID groupId) {
+        return getCategoryGroup(groupId, 200)
+            .as(CategoryGroupResponse.class);
+    }
+
+    public Response getCategoryGroup(UUID groupId, int expectedStatus) {
+        return givenAuth()
+            .get("/api/v1/rails/category-groups/{groupId}", groupId)
+            .then()
+            .statusCode(expectedStatus)
+            .contentType(JSON)
+            .extract().response();
+    }
+
+    public UUID createCategoryGroup(CategoryGroupRequest request) {
+        URI location = URI.create(
+            // http://localhost/api/v1/rails/category-groups/0d4794f8-105b-45c3-8907-2b5afa692af2
+            createCategoryGroup(request, 201).header("Location")
+        );
+        return Utils.getIdFromLocation(location);
+    }
+
+    public Response createCategoryGroup(CategoryGroupRequest request, int expectedStatus) {
+        return givenAuth()
+            .contentType(JSON)
+            .body(request)
+            .post("/api/v1/rails/category-groups")
+            .then()
+            .statusCode(expectedStatus)
+            .extract().response();
+    }
+
+    public Response updateCategoryGroup(UUID groupId, CategoryGroupRequest request) {
+        return updateCategoryGroup(groupId, request, 204);
+    }
+
+    public Response updateCategoryGroup(UUID groupId, CategoryGroupRequest request, int expectedStatus) {
+        return givenAuth()
+            .contentType(JSON)
+            .body(request)
+            .put("/api/v1/rails/category-groups/{groupId}", groupId)
+            .then()
+            .statusCode(expectedStatus)
+            .extract().response();
+    }
+
+    public Response deleteCategoryGroup(UUID groupId) {
+        return deleteCategoryGroup(groupId, 204);
+    }
+
+    public Response deleteCategoryGroup(UUID groupId, int expectedStatus) {
+        return givenAuth()
+            .delete("/api/v1/rails/category-groups/{groupId}", groupId)
+            .then()
+            .statusCode(expectedStatus)
+            .extract().response();
+    }
+
+    public PaginatedCategories getCategories(UUID groupId, int pageIndex, int pageSize) {
+        return givenAuth()
+            .queryParam("page", pageIndex)
+            .queryParam("page-size", pageSize)
+            .get("/api/v1/rails/category-groups/{groupId}/categories", groupId)
+            .then()
+            .statusCode(200)
+            .contentType(JSON)
+            .extract().as(PaginatedCategories.class);
+    }
+
+    public CategoryResponse getCategory(UUID categoryId) {
+        return getCategory(categoryId, 200)
+            .as(CategoryResponse.class);
+    }
+
+    public Response getCategory(UUID categoryId, int expectedStatus) {
+        return givenAuth()
+            .get("/api/v1/rails/categories/{categoryId}", categoryId)
+            .then()
+            .statusCode(expectedStatus)
+            .contentType(JSON)
+            .extract().response();
+    }
+
+    public UUID createCategory(UUID groupId, CategoryRequest request) {
+        URI location = URI.create(
+            createCategory(groupId, request, 201).header("Location")
+        );
+        return Utils.getIdFromLocation(location);
+    }
+
+    public Response createCategory(UUID groupId, CategoryRequest request, int expectedStatus) {
+        return givenAuth()
+            .contentType(JSON)
+            .body(request)
+            .post("/api/v1/rails/category-groups/{groupId}/categories", groupId)
+            .then()
+            .statusCode(expectedStatus)
+            .extract().response();
+    }
+
+    public Response updateCategory(UUID categoryId, CategoryRequest request) {
+        return updateCategory(categoryId, request, 204);
+    }
+
+    public Response updateCategory(UUID categoryId, CategoryRequest request, int expectedStatus) {
+        return givenAuth()
+            .contentType(JSON)
+            .body(request)
+            .put("/api/v1/rails/categories/{categoryId}", categoryId)
+            .then()
+            .statusCode(expectedStatus)
+            .extract().response();
+    }
+
+    public Response deleteCategory(UUID categoryId) {
+        return deleteCategory(categoryId, 204);
+    }
+
+    public Response deleteCategory(UUID categoryId, int expectedStatus) {
+        return givenAuth()
+            .delete("/api/v1/rails/categories/{categoryId}", categoryId)
+            .then()
+            .statusCode(expectedStatus)
+            .extract().response();
+    }
+
+    public List<AccountCategorySelector> getAccountCategorySelectors(UUID categoryId, UUID accountId) {
+        return getAccountCategorySelectors(categoryId, accountId, 200)
+            .as(SELECTORS_LIST);
+    }
+
+    public Response getAccountCategorySelectors(UUID categoryId, UUID accountId, int expectedStatus) {
+        return givenAuth()
+            .get("/api/v1/rails/categories/{categoryId}/selectors/{accountId}", categoryId, accountId)
+            .then()
+            .statusCode(expectedStatus)
+            .contentType(JSON)
+            .extract().response();
+    }
+
+    public List<AccountCategorySelector> setAccountCategorySelectors(UUID categoryId, UUID accountId,
+                                                               Collection<AccountCategorySelector> selectors) {
+        return setAccountCategorySelectors(categoryId, accountId, selectors, 200)
+            .as(SELECTORS_LIST);
+    }
+
+    public Response setAccountCategorySelectors(UUID categoryId, UUID accountId,
+                                                Collection<AccountCategorySelector> selectors,
+                                                int expectedStatus) {
+        return givenAuth()
+            .contentType(JSON)
+            .body(selectors)
+            .put("/api/v1/rails/categories/{categoryId}/selectors/{accountId}", categoryId, accountId)
+            .then()
+            .statusCode(expectedStatus)
+            .contentType(JSON)
+            .extract().response();
+    }
+}

--- a/integration-module/integration-tests/src/main/java/com/hillayes/integration/api/CategoryApi.java
+++ b/integration-module/integration-tests/src/main/java/com/hillayes/integration/api/CategoryApi.java
@@ -1,12 +1,9 @@
 package com.hillayes.integration.api;
 
-import com.hillayes.nordigen.model.EndUserAgreement;
-import com.hillayes.nordigen.model.PaginatedList;
 import com.hillayes.onestop.api.*;
 import io.restassured.common.mapper.TypeRef;
 import io.restassured.response.Response;
 
-import java.net.URI;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -46,12 +43,9 @@ public class CategoryApi extends ApiBase {
             .extract().response();
     }
 
-    public UUID createCategoryGroup(CategoryGroupRequest request) {
-        URI location = URI.create(
-            // http://localhost/api/v1/rails/category-groups/0d4794f8-105b-45c3-8907-2b5afa692af2
-            createCategoryGroup(request, 201).header("Location")
-        );
-        return Utils.getIdFromLocation(location);
+    public CategoryGroupResponse createCategoryGroup(CategoryGroupRequest request) {
+        return createCategoryGroup(request, 201)
+            .as(CategoryGroupResponse.class);
     }
 
     public Response createCategoryGroup(CategoryGroupRequest request, int expectedStatus) {
@@ -61,11 +55,13 @@ public class CategoryApi extends ApiBase {
             .post("/api/v1/rails/category-groups")
             .then()
             .statusCode(expectedStatus)
+            .contentType(JSON)
             .extract().response();
     }
 
-    public Response updateCategoryGroup(UUID groupId, CategoryGroupRequest request) {
-        return updateCategoryGroup(groupId, request, 204);
+    public CategoryGroupResponse updateCategoryGroup(UUID groupId, CategoryGroupRequest request) {
+        return updateCategoryGroup(groupId, request, 200)
+            .as(CategoryGroupResponse.class);
     }
 
     public Response updateCategoryGroup(UUID groupId, CategoryGroupRequest request, int expectedStatus) {
@@ -75,6 +71,7 @@ public class CategoryApi extends ApiBase {
             .put("/api/v1/rails/category-groups/{groupId}", groupId)
             .then()
             .statusCode(expectedStatus)
+            .contentType(JSON)
             .extract().response();
     }
 
@@ -115,11 +112,9 @@ public class CategoryApi extends ApiBase {
             .extract().response();
     }
 
-    public UUID createCategory(UUID groupId, CategoryRequest request) {
-        URI location = URI.create(
-            createCategory(groupId, request, 201).header("Location")
-        );
-        return Utils.getIdFromLocation(location);
+    public CategoryResponse createCategory(UUID groupId, CategoryRequest request) {
+        return createCategory(groupId, request, 201)
+            .as(CategoryResponse.class);
     }
 
     public Response createCategory(UUID groupId, CategoryRequest request, int expectedStatus) {
@@ -129,11 +124,13 @@ public class CategoryApi extends ApiBase {
             .post("/api/v1/rails/category-groups/{groupId}/categories", groupId)
             .then()
             .statusCode(expectedStatus)
+            .contentType(JSON)
             .extract().response();
     }
 
-    public Response updateCategory(UUID categoryId, CategoryRequest request) {
-        return updateCategory(categoryId, request, 204);
+    public CategoryResponse updateCategory(UUID categoryId, CategoryRequest request) {
+        return updateCategory(categoryId, request, 200)
+            .as(CategoryResponse.class);
     }
 
     public Response updateCategory(UUID categoryId, CategoryRequest request, int expectedStatus) {
@@ -143,6 +140,7 @@ public class CategoryApi extends ApiBase {
             .put("/api/v1/rails/categories/{categoryId}", categoryId)
             .then()
             .statusCode(expectedStatus)
+            .contentType(JSON)
             .extract().response();
     }
 

--- a/integration-module/integration-tests/src/main/java/com/hillayes/integration/api/UserConsentApi.java
+++ b/integration-module/integration-tests/src/main/java/com/hillayes/integration/api/UserConsentApi.java
@@ -54,8 +54,9 @@ public class UserConsentApi extends ApiBase {
     }
 
     public URI register(String institutionId, UserConsentRequest consentRequest) {
-        return register(institutionId, consentRequest, 200)
-            .as(URI.class);
+        return URI.create(
+            register(institutionId, consentRequest, 201).header("Location")
+        );
     }
 
     public Response register(String institutionId, UserConsentRequest consentRequest, int expectedStatus) {
@@ -65,7 +66,6 @@ public class UserConsentApi extends ApiBase {
             .post("/api/v1/rails/consents/{institutionId}", institutionId)
             .then()
             .statusCode(expectedStatus)
-            .contentType(JSON)
             .extract().response();
     }
 

--- a/integration-module/integration-tests/src/main/java/com/hillayes/integration/api/Utils.java
+++ b/integration-module/integration-tests/src/main/java/com/hillayes/integration/api/Utils.java
@@ -1,0 +1,25 @@
+package com.hillayes.integration.api;
+
+import java.net.URI;
+import java.util.UUID;
+
+public class Utils {
+    /**
+     * Extracts the UUID from the last segment of the path of a URI.
+     * @param location The URI to extract the UUID from.
+     * @return The UUID extracted from the URI, or null if the URI is null or does not contain a UUID.
+     */
+    public static UUID getIdFromLocation(URI location) {
+        if (location == null) {
+            return null;
+        }
+
+        String path = location.getPath();
+        int index = path.lastIndexOf('/') + 1;
+        if ((index <= 0) || (index >= path.length())) {
+            return null;
+        }
+
+        return UUID.fromString(path.substring(index));
+    }
+}

--- a/integration-module/integration-tests/src/test/java/com/hillayes/integration/test/category/CategoryTestIT.java
+++ b/integration-module/integration-tests/src/test/java/com/hillayes/integration/test/category/CategoryTestIT.java
@@ -1,0 +1,408 @@
+package com.hillayes.integration.test.category;
+
+import com.google.common.collect.Streams;
+import com.hillayes.integration.api.*;
+import com.hillayes.integration.api.admin.RailAgreementAdminApi;
+import com.hillayes.integration.api.admin.RailRequisitionAdminApi;
+import com.hillayes.integration.test.ApiTestBase;
+import com.hillayes.integration.test.util.UserEntity;
+import com.hillayes.integration.test.util.UserUtils;
+import com.hillayes.nordigen.model.EndUserAgreement;
+import com.hillayes.nordigen.model.PaginatedList;
+import com.hillayes.nordigen.model.Requisition;
+import com.hillayes.nordigen.model.RequisitionStatus;
+import com.hillayes.onestop.api.*;
+import com.hillayes.sim.email.SendWithBlueSimulator;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.*;
+import java.util.stream.IntStream;
+
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CategoryTestIT extends ApiTestBase {
+    @Test
+    public void testCategoryGroups() {
+        // given: a user
+        UserEntity user = UserEntity.builder()
+            .username(randomAlphanumeric(20))
+            .givenName(randomAlphanumeric(10))
+            .password(randomAlphanumeric(30))
+            .email(randomAlphanumeric(30))
+            .build();
+        user = UserUtils.createUser(getWiremockPort(), user);
+
+        CategoryApi categoryApi = new CategoryApi(user.getAuthTokens());
+
+        // when: the user creates a category group
+        CategoryGroupRequest createGroupRequest = new CategoryGroupRequest()
+            .name(randomAlphanumeric(20))
+            .description(randomAlphanumeric(50));
+        UUID groupId = categoryApi.createCategoryGroup(createGroupRequest);
+
+        // then: the ID of the new group is returned
+        assertNotNull(groupId);
+
+        // when: the category group is retrieved
+        CategoryGroupResponse categoryGroup = categoryApi.getCategoryGroup(groupId);
+
+        // then: the category group is returned
+        assertEquals(groupId, categoryGroup.getId());
+        assertEquals(createGroupRequest.getName(), categoryGroup.getName());
+        assertEquals(createGroupRequest.getDescription(), categoryGroup.getDescription());
+
+        // when: the category group is updated
+        CategoryGroupRequest updateGroupRequest = new CategoryGroupRequest()
+            .name(randomAlphanumeric(20))
+            .description(randomAlphanumeric(50));
+        categoryApi.updateCategoryGroup(groupId, updateGroupRequest);
+
+        // and: the updated category group is retrieved
+        CategoryGroupResponse updatedGroup = categoryApi.getCategoryGroup(groupId);
+
+        // then: the category group is returned
+        assertEquals(groupId, updatedGroup.getId());
+        assertEquals(updateGroupRequest.getName(), updatedGroup.getName());
+        assertEquals(updateGroupRequest.getDescription(), updatedGroup.getDescription());
+
+        // when: 19 more category groups are created
+        List<UUID> allGroupIds = new ArrayList<>();
+        allGroupIds.add(groupId);
+        allGroupIds.addAll(IntStream.range(0, 19)
+            .mapToObj(i -> new CategoryGroupRequest()
+                .name(randomAlphanumeric(20))
+                .description(randomAlphanumeric(50))
+            )
+            .map(categoryApi::createCategoryGroup)
+            .toList()
+        );
+
+        // and: a page of ALL category groups are retrieved
+        PaginatedCategoryGroups categoryGroups = categoryApi.getCategoryGroups(0, 20);
+
+        // then: the page counts are correct
+        assertEquals(0, categoryGroups.getPage());
+        assertEquals(20, categoryGroups.getPageSize());
+        assertEquals(20, categoryGroups.getCount());
+        assertEquals(20, categoryGroups.getTotal());
+        assertEquals(1, categoryGroups.getTotalPages());
+
+        // and: the page contains all category groups
+        assertNotNull(categoryGroups.getItems());
+        assertEquals(20, categoryGroups.getItems().size());
+        allGroupIds.forEach(id ->
+            assertTrue(categoryGroups.getItems().stream().anyMatch(group -> group.getId().equals(id)))
+        );
+    }
+
+    @Test
+    public void testCategories() {
+        // given: a user
+        UserEntity user = UserEntity.builder()
+            .username(randomAlphanumeric(20))
+            .givenName(randomAlphanumeric(10))
+            .password(randomAlphanumeric(30))
+            .email(randomAlphanumeric(30))
+            .build();
+        user = UserUtils.createUser(getWiremockPort(), user);
+
+        CategoryApi categoryApi = new CategoryApi(user.getAuthTokens());
+
+        // and: the user creates a category group
+        CategoryGroupRequest createGroupRequest = new CategoryGroupRequest()
+            .name(randomAlphanumeric(20))
+            .description(randomAlphanumeric(50));
+        UUID groupId = categoryApi.createCategoryGroup(createGroupRequest);
+        assertNotNull(groupId);
+
+        // when: the user creates a category within the group
+        CategoryRequest createCategoryRequest = new CategoryRequest()
+            .name(randomAlphanumeric(20))
+            .description(randomAlphanumeric(50))
+            .colour("#112233");
+
+        // then: the ID of the new category is returned
+        UUID categoryId = categoryApi.createCategory(groupId, createCategoryRequest);
+
+        // when: the category is retrieved
+        CategoryResponse category = categoryApi.getCategory(categoryId);
+
+        // then: the category is returned
+        assertEquals(categoryId, category.getId());
+        assertEquals(createCategoryRequest.getName(), category.getName());
+        assertEquals(createCategoryRequest.getDescription(), category.getDescription());
+        assertEquals(createCategoryRequest.getColour(), category.getColour());
+
+        // when: the category is updated
+        CategoryRequest updateCategoryRequest = new CategoryRequest()
+            .name(randomAlphanumeric(20))
+            .description(randomAlphanumeric(50))
+            .colour("#445566");
+        categoryApi.updateCategory(categoryId, updateCategoryRequest);
+
+        // and: the updated category is retrieved
+        CategoryResponse updatedCategory = categoryApi.getCategory(categoryId);
+
+        // then: the category is returned
+        assertEquals(categoryId, updatedCategory.getId());
+        assertEquals(groupId, updatedCategory.getGroupId());
+        assertEquals(updateCategoryRequest.getName(), updatedCategory.getName());
+        assertEquals(updateCategoryRequest.getDescription(), updatedCategory.getDescription());
+        assertEquals(updateCategoryRequest.getColour(), updatedCategory.getColour());
+
+        // when: 19 more categories are created
+        List<UUID> allCategoryIds = new ArrayList<>();
+        allCategoryIds.add(categoryId);
+        allCategoryIds.addAll(IntStream.range(0, 19)
+            .mapToObj(i -> new CategoryRequest()
+                .name(randomAlphanumeric(20))
+                .description(randomAlphanumeric(50))
+                .colour("#778899")
+            )
+            .map(request -> categoryApi.createCategory(groupId, request))
+            .toList()
+        );
+
+        // and: a page of ALL category are retrieved for the group
+        PaginatedCategories categories = categoryApi.getCategories(groupId, 0, 20);
+
+        // then: the page counts are correct
+        assertEquals(0, categories.getPage());
+        assertEquals(20, categories.getPageSize());
+        assertEquals(20, categories.getCount());
+        assertEquals(20, categories.getTotal());
+        assertEquals(1, categories.getTotalPages());
+
+        // and: the page contains all category
+        assertNotNull(categories.getItems());
+        assertEquals(20, categories.getItems().size());
+        allCategoryIds.forEach(id ->
+            assertTrue(categories.getItems().stream().anyMatch(cat -> cat.getId().equals(id)))
+        );
+
+        // when: the category is deleted
+        categoryApi.deleteCategory(categoryId);
+
+        // then: the category can no longer be retrieved
+        withServiceError(categoryApi.getCategory(categoryId, 404), errorResponse -> {
+            ServiceError error = errorResponse.getErrors().get(0);
+
+            // then: a not-found error is returned
+            assertEquals("ENTITY_NOT_FOUND", error.getMessageId());
+            assertNotNull(error.getContextAttributes());
+            assertEquals("Category", error.getContextAttributes().get("entity-type"));
+            assertEquals(categoryId.toString(), error.getContextAttributes().get("entity-id"));
+        });
+
+        // when: the category group is deleted
+        categoryApi.deleteCategoryGroup(groupId);
+
+        // then: the category group can no longer be retrieved
+        withServiceError(categoryApi.getCategoryGroup(groupId, 404), errorResponse -> {
+            ServiceError error = errorResponse.getErrors().get(0);
+
+            // then: a not-found error is returned
+            assertEquals("ENTITY_NOT_FOUND", error.getMessageId());
+            assertNotNull(error.getContextAttributes());
+            assertEquals("CategoryGroup", error.getContextAttributes().get("entity-type"));
+            assertEquals(groupId.toString(), error.getContextAttributes().get("entity-id"));
+        });
+
+        // and: none of its categories can be retrieved
+        allCategoryIds.forEach(id ->
+            categoryApi.getCategory(id, 404)
+        );
+    }
+
+    @Test
+    public void testCategorySelectors() {
+        // given: the admin user signs in
+        AuthApi authApi = new AuthApi();
+        Map<String, String> adminAuthTokens = authApi.login("admin", "password");
+        assertNotNull(adminAuthTokens);
+        assertEquals(3, adminAuthTokens.size());
+
+        // and: a user is created
+        UserEntity user = UserEntity.builder()
+            .username(randomAlphanumeric(20))
+            .givenName(randomAlphanumeric(10))
+            .password(randomAlphanumeric(30))
+            .email(randomAlphanumeric(30))
+            .build();
+        user = UserUtils.createUser(getWiremockPort(), user);
+
+        // and: the user creates accounts - and the first account is selected
+        UUID accountId = createAccounts(adminAuthTokens, user).get(0);
+
+        CategoryApi categoryApi = new CategoryApi(user.getAuthTokens());
+
+        // and: the user creates a category group
+        UUID groupId = categoryApi.createCategoryGroup(new CategoryGroupRequest()
+            .name(randomAlphanumeric(20)));
+        assertNotNull(groupId);
+
+        // and: the user creates a category within the group
+        UUID categoryId = categoryApi.createCategory(groupId, new CategoryRequest()
+            .name(randomAlphanumeric(20)));
+        assertNotNull(categoryId);
+
+        // when: the user creates category selectors
+        List<AccountCategorySelector> setSelectorsRequest = IntStream.range(0, 10)
+            .mapToObj(i -> new AccountCategorySelector()
+                .creditorContains(randomAlphanumeric(10))
+                .refContains(randomAlphanumeric(10))
+                .infoContains(randomAlphanumeric(10))
+            ).toList();
+        List<AccountCategorySelector> selectors = categoryApi.setAccountCategorySelectors(categoryId, accountId, setSelectorsRequest);
+
+        // then: the new selectors are returned
+        compare(setSelectorsRequest, selectors);
+
+        // when: the selectors are retrieved
+        selectors = categoryApi.getAccountCategorySelectors(categoryId, accountId);
+
+        // then: the selectors are returned
+        compare(setSelectorsRequest, selectors);
+
+        // when: the selectors are modified
+        // take first 5 original and add 10 new
+        List<AccountCategorySelector> updateSelectorsRequest = Streams.concat(
+                setSelectorsRequest.stream().limit(5),
+                IntStream.range(0, 10).mapToObj(i -> new AccountCategorySelector()
+                    .creditorContains(randomAlphanumeric(10))
+                    .refContains(randomAlphanumeric(10))
+                    .infoContains(randomAlphanumeric(10))
+                )
+            )
+            .toList();
+
+        selectors = categoryApi.setAccountCategorySelectors(categoryId, accountId, updateSelectorsRequest);
+
+        // then: the updated selectors are returned
+        compare(updateSelectorsRequest, selectors);
+
+        // when: the updated selectors are retrieved
+        selectors = categoryApi.getAccountCategorySelectors(categoryId, accountId);
+
+        // then: the updated selectors are returned
+        compare(updateSelectorsRequest, selectors);
+
+        // when: the category is deleted
+        categoryApi.deleteCategory(categoryId);
+
+        // then: the category can no longer be retrieved
+        withServiceError(categoryApi.getCategory(categoryId, 404), errorResponse -> {
+            ServiceError error = errorResponse.getErrors().get(0);
+
+            // then: a not-found error is returned
+            assertEquals("ENTITY_NOT_FOUND", error.getMessageId());
+            assertNotNull(error.getContextAttributes());
+            assertEquals("Category", error.getContextAttributes().get("entity-type"));
+            assertEquals(categoryId.toString(), error.getContextAttributes().get("entity-id"));
+        });
+
+        // and: the selectors can no longer be retrieved
+        withServiceError(categoryApi.getAccountCategorySelectors(categoryId, accountId, 404), errorResponse -> {
+            ServiceError error = errorResponse.getErrors().get(0);
+
+            // then: a not-found error is returned
+            assertEquals("ENTITY_NOT_FOUND", error.getMessageId());
+            assertNotNull(error.getContextAttributes());
+            assertEquals("Category", error.getContextAttributes().get("entity-type"));
+            assertEquals(categoryId.toString(), error.getContextAttributes().get("entity-id"));
+        });
+    }
+
+    private void compare(Collection<AccountCategorySelector> expected,
+                         Collection<AccountCategorySelector> actual) {
+        assertNotNull(actual);
+        assertEquals(expected.size(), actual.size());
+        expected.forEach(request ->
+            assertTrue(actual.stream().anyMatch(selector ->
+                request.getCreditorContains().equals(selector.getCreditorContains()) &&
+                    request.getRefContains().equals(selector.getRefContains()) &&
+                    request.getInfoContains().equals(selector.getInfoContains())
+            ))
+        );
+    }
+
+    private List<UUID> createAccounts(Map<String, String> adminAuthTokens, UserEntity user) {
+        // establish authenticated APIs
+        RailAgreementAdminApi agreementAdminApi = new RailAgreementAdminApi(adminAuthTokens);
+        RailRequisitionAdminApi requisitionAdminApi = new RailRequisitionAdminApi(adminAuthTokens);
+        InstitutionApi institutionApi = new InstitutionApi(user.getAuthTokens());
+        UserConsentApi userConsentApi = new UserConsentApi(user.getAuthTokens());
+        AccountApi accountApi = new AccountApi(user.getAuthTokens());
+
+        // and: the user can identify the institution
+        InstitutionResponse institution = institutionApi.getInstitution("SANDBOXFINANCE_SFIN0000");
+        assertNotNull(institution);
+
+        // when: the user initiates a consent request for the institution
+        UserConsentRequest consentRequest = new UserConsentRequest()
+            .callbackUri(URI.create("http://mock/callback/uri"));
+        userConsentApi.register(institution.getId(), consentRequest);
+
+        // and: a user-consent record is waiting to be given
+        UserConsentResponse userConsent = userConsentApi.getConsentForInstitution(institution.getId());
+        assertEquals("INITIATED", userConsent.getStatus());
+
+        // and: an end-user agreement is created for the institution
+        PaginatedList<EndUserAgreement> agreements = agreementAdminApi.list(0, 100);
+        assertNotNull(agreements);
+        assertEquals(1, agreements.count); // only one as we clear data on each test
+        EndUserAgreement agreement = agreements.results.get(0);
+
+        // and: a requisition record is created - only one as we clear data on each test
+        PaginatedList<Requisition> requisitions = requisitionAdminApi.list(0, 100);
+        assertEquals(1, requisitions.count);
+        Requisition requisition = requisitions.results.get(0);
+
+        // when: the requisition process is complete
+        while (requisition.status != RequisitionStatus.LN) {
+            requisition = requisitionAdminApi.get(requisition.id);
+        }
+
+        // then: the requisitioned accounts are identified
+        assertFalse(requisition.accounts.isEmpty());
+
+        try (SendWithBlueSimulator emailSim = new SendWithBlueSimulator(getWiremockPort())) {
+            // when: the success response is returned from the rails service
+            Response response = userConsentApi.consentResponse(institution.getProvider(), requisition.reference, null, null);
+
+            // then: the redirect response is the original callback URI
+            assertEquals(consentRequest.getCallbackUri().toString(), response.getHeader("Location"));
+
+            // and: a confirmation email is sent to the user
+            emailSim.verifyEmailSent(user.getEmail(), "Your One-Stop access to " + institution.getName(),
+                await().atMost(Duration.ofSeconds(60)));
+
+            // and: the user can retrieve their consent record
+            UserConsentResponse consentForInstitution = userConsentApi.getConsentForInstitution(institution.getId());
+            assertNotNull(consentForInstitution);
+
+            // and: consent status shows it has been given
+            assertEquals("GIVEN", consentForInstitution.getStatus());
+
+            // and: no error was recorded during consent
+            assertNull(consentForInstitution.getErrorCode());
+        }
+
+        // when: the user's accounts have been polled by the service
+        int accountCount = requisition.accounts.size();
+        await().atMost(Duration.ofSeconds(30)).pollInterval(Duration.ofSeconds(1))
+            .untilAsserted(() ->
+                assertEquals(accountCount, accountApi.getAccounts(0, accountCount).getCount())
+            );
+
+        return accountApi.getAccounts(0, 5)
+            .getItems().stream()
+            .map(AccountResponse::getId)
+            .toList();
+    }
+}

--- a/openapi-doc/src/main/spec/one-stop-openapi.yaml
+++ b/openapi-doc/src/main/spec/one-stop-openapi.yaml
@@ -701,7 +701,7 @@ paths:
             Any occurrence of the value within the transaction reference will match. The comparison is case-insensitive.
           required: false
           schema:
-              type: string
+            type: string
         - name: "info"
           in: "query"
           description: |
@@ -816,15 +816,72 @@ paths:
         500:
           description: Internal server error
 
-  /rails/categories:
+  /rails/category/groups:
     get:
       tags: [ "categories" ]
-      summary: Get all categories
-      description: Get all categories for the authenticated user
+      summary: Get all category groups
+      description: Get all category groups for the authenticated user
+      operationId: GetCategoryGroups
+      security:
+        - cookieAuth: [ ]
+      parameters:
+        - $ref: '#/components/parameters/PageIndexParam'
+        - $ref: '#/components/parameters/PageSizeParam'
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedCategoryGroups'
+        401:
+          description: Unauthorized
+        500:
+          description: Internal server error
+    post:
+      tags: [ "categories" ]
+      summary: Create category group
+      description: Creates a new category group for the authenticated user.
+      operationId: createCategoryGroup
+      security:
+        - cookieAuth: [ ]
+      requestBody:
+        description: The details of the new category group.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CategoryGroupRequest'
+      responses:
+        201:
+          description: successful operation
+          headers:
+            Location:
+              description: The location of the created category group
+              schema:
+                type: string
+                format: uri
+        401:
+          description: Unauthorized
+        500:
+          description: Internal server error
+
+  /rails/category/groups/{groupId}:
+    get:
+      tags: [ "categories" ]
+      summary: Get all categories within group
+      description: Get all categories within the identified group for the authenticated user
       operationId: getCategories
       security:
         - cookieAuth: [ ]
       parameters:
+        - name: "groupId"
+          in: "path"
+          description: ID of category group whose categories are to be returned
+          required: true
+          schema:
+            type: string
+            format: uuid
         - $ref: '#/components/parameters/PageIndexParam'
         - $ref: '#/components/parameters/PageSizeParam'
       responses:
@@ -840,11 +897,19 @@ paths:
           description: Internal server error
     post:
       tags: [ "categories" ]
-      summary: Create category
-      description: Creates a new category for the authenticated user.
+      summary: Create category within group
+      description: Creates a new category within the identified group for the authenticated user.
       operationId: createCategory
       security:
         - cookieAuth: [ ]
+      parameters:
+        - name: "groupId"
+          in: "path"
+          description: ID of category group into which the new category is to placed.
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         description: The details of the new category.
         required: true
@@ -1827,6 +1892,35 @@ components:
           description: The notification message to be displayed.
           type: string
 
+    CategoryGroupRequest:
+      description: A named group by which categories can be arranged.
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: The category group's name (unique to the user's category groups).
+          example: Investments
+        description:
+          type: string
+          description: The category group's description.
+          example: Breakdown of investment income and expenditure.
+
+    CategoryGroupResponse:
+      description: A named category group by which categories can be arranged.
+      allOf:
+        - $ref: '#/components/schemas/CategoryGroupRequest'
+        - type: object
+          required:
+            - id
+          properties:
+            id:
+              type: string
+              format: uuid
+              description: The category group Id
+              example: 07061d76-74f3-4163-aa07-fb6909681f81
+
     CategoryRequest:
       description: A named category by which transactions can be grouped.
       type: object
@@ -1853,11 +1947,17 @@ components:
         - type: object
           required:
             - id
+            - groupId
           properties:
             id:
               type: string
               format: uuid
               description: The category Id
+              example: 07061d76-74f3-4163-aa07-fb6909681f81
+            groupId:
+              type: string
+              format: uuid
+              description: The category's group Id
               example: 07061d76-74f3-4163-aa07-fb6909681f81
 
     AccountCategorySelector:
@@ -2083,6 +2183,17 @@ components:
               description: The list of notifications
               items:
                 $ref: '#/components/schemas/NotificationResponse'
+
+    PaginatedCategoryGroups:
+      allOf:
+        - $ref: '#/components/schemas/PaginatedItems'
+        - type: object
+          properties:
+            items:
+              type: array
+              description: The list of categories
+              items:
+                $ref: '#/components/schemas/CategoryGroupResponse'
 
     PaginatedCategories:
       allOf:

--- a/openapi-doc/src/main/spec/one-stop-openapi.yaml
+++ b/openapi-doc/src/main/spec/one-stop-openapi.yaml
@@ -864,6 +864,10 @@ paths:
               schema:
                 type: string
                 format: uri
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CategoryGroupResponse'
         401:
           description: Unauthorized
         500:
@@ -922,8 +926,12 @@ paths:
             schema:
               $ref: '#/components/schemas/CategoryGroupRequest'
       responses:
-        204:
+        200:
           description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CategoryGroupResponse'
         401:
           description: Unauthorized
         404:
@@ -1021,6 +1029,10 @@ paths:
               schema:
                 type: string
                 format: uri
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CategoryResponse'
         401:
           description: Unauthorized
         500:
@@ -1079,8 +1091,12 @@ paths:
             schema:
               $ref: '#/components/schemas/CategoryRequest'
       responses:
-        204:
+        200:
           description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CategoryResponse'
         401:
           description: Unauthorized
         404:
@@ -1203,7 +1219,7 @@ paths:
         500:
           description: Internal server error
 
-  /rails/category-group/{groupId}/statistics:
+  /rails/category-groups/{groupId}/statistics:
     get:
       tags: [ "categories" ]
       summary: Get category statistics
@@ -2094,18 +2110,29 @@ components:
       description: A summary of the transactions in a category.
       type: object
       required:
-        - category
+        - groupId
+        - groupName
+        - categoryName
         - count
         - total
         - credit
         - debit
       properties:
+        groupId:
+          type: string
+          format: uuid
+          description: The category group Id.
+          example: 07061d76-74f3-4163-aa07-fb6909681f81
+        groupName:
+          type: string
+          description: The category group's name
+          example: Groceries
         categoryId:
           type: string
           format: uuid
           description: The category Id. This will be null for uncategorised transactions.
           example: 07061d76-74f3-4163-aa07-fb6909681f81
-        category:
+        categoryName:
           type: string
           description: The category's name
           example: Groceries

--- a/openapi-doc/src/main/spec/one-stop-openapi.yaml
+++ b/openapi-doc/src/main/spec/one-stop-openapi.yaml
@@ -816,7 +816,7 @@ paths:
         500:
           description: Internal server error
 
-  /rails/category/groups:
+  /rails/category-groups:
     get:
       tags: [ "categories" ]
       summary: Get all category groups
@@ -838,10 +838,13 @@ paths:
           description: Unauthorized
         500:
           description: Internal server error
+
     post:
       tags: [ "categories" ]
       summary: Create category group
-      description: Creates a new category group for the authenticated user.
+      description: |
+        Creates a new category group for the authenticated user. The name of the group
+        must be unique within the user's category groups.
       operationId: createCategoryGroup
       security:
         - cookieAuth: [ ]
@@ -866,7 +869,96 @@ paths:
         500:
           description: Internal server error
 
-  /rails/category/groups/{groupId}:
+  /rails/category-groups/{groupId}:
+    get:
+      tags: [ "categories" ]
+      summary: Get category group
+      description: Get the authenticated user's identified category group.
+      operationId: getCategoryGroup
+      security:
+        - cookieAuth: [ ]
+      parameters:
+        - name: "groupId"
+          in: "path"
+          description: ID of category group to be returned
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CategoryGroupResponse'
+        401:
+          description: Unauthorized
+        404:
+          description: Category group not found
+        500:
+          description: Internal server error
+
+    put:
+      tags: [ "categories" ]
+      summary: Update category group
+      description: Updates the authenticated user's identified category group.
+      operationId: updateCategoryGroup
+      security:
+        - cookieAuth: [ ]
+      parameters:
+        - name: "groupId"
+          in: "path"
+          description: ID of category group to be updated
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: The updated details of the category.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CategoryGroupRequest'
+      responses:
+        204:
+          description: successful operation
+        401:
+          description: Unauthorized
+        404:
+          description: Category group not found
+        500:
+          description: Internal server error
+
+    delete:
+      tags: [ "categories" ]
+      summary: Delete category group
+      description: |
+        Deletes the authenticated user's identified category group. All categories and
+        category selectors within the group will also be deleted.
+      operationId: deleteCategoryGroup
+      security:
+        - cookieAuth: [ ]
+      parameters:
+        - name: "groupId"
+          in: "path"
+          description: ID of category group to be deleted
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        204:
+          description: successful operation
+        401:
+          description: Unauthorized
+        404:
+          description: Category group not found
+        500:
+          description: Internal server error
+
+  /rails/category-groups/{groupId}/categories:
     get:
       tags: [ "categories" ]
       summary: Get all categories within group
@@ -893,8 +985,11 @@ paths:
                 $ref: '#/components/schemas/PaginatedCategories'
         401:
           description: Unauthorized
+        404:
+          description: Category group not found
         500:
           description: Internal server error
+
     post:
       tags: [ "categories" ]
       summary: Create category within group
@@ -956,6 +1051,8 @@ paths:
                 $ref: '#/components/schemas/CategoryResponse'
         401:
           description: Unauthorized
+        404:
+          description: Category not found
         500:
           description: Internal server error
 
@@ -986,6 +1083,8 @@ paths:
           description: successful operation
         401:
           description: Unauthorized
+        404:
+          description: Category not found
         500:
           description: Internal server error
 
@@ -1005,14 +1104,12 @@ paths:
             type: string
             format: uuid
       responses:
-        200:
+        204:
           description: successful operation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CategoryResponse'
         401:
           description: Unauthorized
+        404:
+          description: Category not found
         500:
           description: Internal server error
 
@@ -1056,6 +1153,7 @@ paths:
           description: Category or account not found
         500:
           description: Internal server error
+
     put:
       tags: [ "categories" ]
       summary: Set category selectors
@@ -1105,15 +1203,24 @@ paths:
         500:
           description: Internal server error
 
-  /rails/categories/statistics:
+  /rails/category-group/{groupId}/statistics:
     get:
       tags: [ "categories" ]
       summary: Get category statistics
-      description: Get the category statistics for the authenticated user, across all their accounts.
+      description: |
+        Get the transaction statistics for the identified category group, across all
+        accounts of the authenticated user.
       operationId: getCategoryStatistics
       security:
         - cookieAuth: [ ]
       parameters:
+        - name: "groupId"
+          in: "path"
+          description: ID of category group for which the statistics are to be returned
+          required: true
+          schema:
+            type: string
+            format: uuid
         - name: "from-date"
           in: "query"
           description: The date, inclusive, from which the transaction should start.
@@ -1900,7 +2007,7 @@ components:
       properties:
         name:
           type: string
-          description: The category group's name (unique to the user's category groups).
+          description: The category group's name. Must be case-sensitively unique to the user's category groups.
           example: Investments
         description:
           type: string
@@ -1929,7 +2036,7 @@ components:
       properties:
         name:
           type: string
-          description: The category's name (unique to the user's categories).
+          description: The category's name. Must be case-sensitively unique to the parent category group.
           example: Groceries
         description:
           type: string

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
 
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>3.12.3</quarkus.platform.version>
+        <quarkus.platform.version>3.13.0</quarkus.platform.version>
 
         <quarkus.jackson.serialization-inclusion>non-null</quarkus.jackson.serialization-inclusion>
 

--- a/rail-module/rail-service/src/main/java/com/hillayes/rail/domain/Category.java
+++ b/rail-module/rail-service/src/main/java/com/hillayes/rail/domain/Category.java
@@ -31,11 +31,10 @@ public class Category {
     private long version;
 
     /**
-     * The user to whom this category belongs.
+     * The category group to which this category is belongs.
      */
-    @EqualsAndHashCode.Include
-    @Column(name = "user_id", nullable = false)
-    private UUID userId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private CategoryGroup group;
 
     /**
      * The name of the category. This is unique for each user.

--- a/rail-module/rail-service/src/main/java/com/hillayes/rail/domain/CategoryGroup.java
+++ b/rail-module/rail-service/src/main/java/com/hillayes/rail/domain/CategoryGroup.java
@@ -1,0 +1,117 @@
+package com.hillayes.rail.domain;
+
+import com.hillayes.commons.Strings;
+import com.hillayes.exception.common.MissingParameterException;
+import com.hillayes.rail.errors.CategoryAlreadyExistsException;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+/**
+ * Category groups allow users to arrange their categories into groups. This can
+ * be useful for organizing categories into logical groups, such as "Income" and
+ * "Expenses".
+ */
+@Entity
+@Table(name = "category_group")
+@Getter
+@Builder(builderClassName = "Builder")
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@ToString(onlyExplicitlyIncluded = true)
+public class CategoryGroup {
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @Setter
+    private UUID id;
+
+    @Version
+    @Column(name = "version")
+    private long version;
+
+    /**
+     * The user to whom this category group belongs.
+     */
+    @EqualsAndHashCode.Include
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    /**
+     * The name of the category. This is unique for each user.
+     */
+    @EqualsAndHashCode.Include
+    @ToString.Include
+    @Setter
+    @Column(nullable = false)
+    private String name;
+
+    /**
+     * A description of the category.
+     */
+    @Setter
+    private String description;
+
+    /**
+     * The categories that belong to this group.
+     */
+    @OneToMany(mappedBy = "group", fetch = FetchType.LAZY, orphanRemoval = true, cascade = CascadeType.ALL)
+    @lombok.Builder.Default
+    private Set<Category> categories = new HashSet<>();
+
+    public Optional<Category> getCategory(UUID id) {
+        return categories.stream()
+            .filter(c -> c.getId().equals(id))
+            .findAny();
+    }
+
+    public Optional<Category> getCategory(String name) {
+        return categories.stream()
+            .filter(c -> c.getName().equalsIgnoreCase(name))
+            .findAny();
+    }
+
+    /**
+     * Adds a category to this group; ensuring that the category is associated with
+     * this group and that the category name is unique within this group.
+     *
+     * @param name The name of the category.
+     * @param modifier A consumer that can be used to modify the category as it is added.
+     * @return The new category.
+     */
+    public Category addCategory(String name,
+                                Consumer<Category.Builder> modifier) {
+        String newName = Strings.trimOrNull(name);
+        if (newName == null) {
+            throw new MissingParameterException("Category.name");
+        }
+
+        categories.stream()
+            .filter(c -> c.getName().equalsIgnoreCase(newName))
+            .findAny()
+            .ifPresent(c -> {
+                throw new CategoryAlreadyExistsException(c);
+            });
+
+        Category.Builder builder = Category.builder()
+            .group(this)
+            .name(name);
+
+        if (modifier != null) {
+            modifier.accept(builder);
+        }
+
+        Category category = builder.build();
+        categories.add(category);
+        return category;
+    }
+
+    public boolean removeCategory(Category category) {
+        return categories.remove(category);
+    }
+}

--- a/rail-module/rail-service/src/main/java/com/hillayes/rail/domain/CategoryStatistics.java
+++ b/rail-module/rail-service/src/main/java/com/hillayes/rail/domain/CategoryStatistics.java
@@ -14,6 +14,17 @@ import java.util.UUID;
 @RegisterForReflection
 public class CategoryStatistics {
     /**
+     * The category group id.
+     */
+    @EqualsAndHashCode.Include
+    private UUID groupId;
+
+    /**
+     * The category group name.
+     */
+    private String groupName;
+
+    /**
      * The category name.
      */
     @EqualsAndHashCode.Include

--- a/rail-module/rail-service/src/main/java/com/hillayes/rail/errors/CategoryGroupAlreadyExistsException.java
+++ b/rail-module/rail-service/src/main/java/com/hillayes/rail/errors/CategoryGroupAlreadyExistsException.java
@@ -1,0 +1,12 @@
+package com.hillayes.rail.errors;
+
+import com.hillayes.exception.MensaException;
+import com.hillayes.rail.domain.CategoryGroup;
+
+public class CategoryGroupAlreadyExistsException extends MensaException {
+    public CategoryGroupAlreadyExistsException(CategoryGroup categoryGroup) {
+        super(RailsErrorCodes.CATEGORY_GROUP_ALREADY_EXISTS);
+        addParameter("id", categoryGroup.getId());
+        addParameter("name", categoryGroup.getName());
+    }
+}

--- a/rail-module/rail-service/src/main/java/com/hillayes/rail/errors/RailsErrorCodes.java
+++ b/rail-module/rail-service/src/main/java/com/hillayes/rail/errors/RailsErrorCodes.java
@@ -10,7 +10,8 @@ public enum RailsErrorCodes implements ErrorCode {
     REGISTRATION_NOT_FOUND(Severity.info, "Unable to identify registration consent record.", INTERNAL_SERVER_ERROR_STATUS),
     RAIL_NOT_FOUND(Severity.error, "Unable to identify rail.", INTERNAL_SERVER_ERROR_STATUS),
     FAILED_TO_DELETE_RAIL_CONSENT(Severity.error, "Failed to delete consent.", INTERNAL_SERVER_ERROR_STATUS),
-    CATEGORY_ALREADY_EXISTS(Severity.info, "You have already category of that name.", CONFLICT_STATUS);
+    CATEGORY_GROUP_ALREADY_EXISTS(Severity.info, "You have already category group of that name.", CONFLICT_STATUS),
+    CATEGORY_ALREADY_EXISTS(Severity.info, "You have already category of that name within the group.", CONFLICT_STATUS);
 
     private final Severity severity;
     private final String message;

--- a/rail-module/rail-service/src/main/java/com/hillayes/rail/event/consumer/UserTopicConsumer.java
+++ b/rail-module/rail-service/src/main/java/com/hillayes/rail/event/consumer/UserTopicConsumer.java
@@ -28,7 +28,7 @@ public class UserTopicConsumer implements EventConsumer {
         if (UserDeleted.class.getName().equals(payloadClass)) {
             UserDeleted payload = eventPacket.getPayloadContent();
             userConsentService.deleteAllConsents(payload.getUserId());
-            categoryService.deleteAllCategories(payload.getUserId());
+            categoryService.deleteAllCategoryGroups(payload.getUserId());
         }
     }
 }

--- a/rail-module/rail-service/src/main/java/com/hillayes/rail/repository/AccountTransactionRepository.java
+++ b/rail-module/rail-service/src/main/java/com/hillayes/rail/repository/AccountTransactionRepository.java
@@ -40,8 +40,9 @@ public class AccountTransactionRepository extends RepositoryBase<AccountTransact
         "and t.booking_datetime >= :startDate " +
         "and t.booking_datetime < :endDate " +
         "and not exists ( " +
-        "  select 1 from rails.category_selector cs where " +
-        "    cs.account_id = t.account_id " +
+        "  select 1 from rails.category_selector cs " +
+        "  join rails.category c on c.id = cs.category_id and c.group_id = :groupId " +
+        "  where cs.account_id = t.account_id " +
         "    and (cs.info_contains is null or t.additional_information like concat('%', cs.info_contains, '%')) " +
         "    and (cs.ref_contains is null or t.reference like concat('%', cs.ref_contains, '%')) " +
         "    and (cs.creditor_contains is null or t.creditor_name like concat('%', cs.creditor_contains, '%')) " +
@@ -97,10 +98,11 @@ public class AccountTransactionRepository extends RepositoryBase<AccountTransact
             .getResultList();
     }
 
-    public List<AccountTransaction> findUncategorised(UUID userId,
+    public List<AccountTransaction> findUncategorised(UUID userId, UUID groupId,
                                                       Instant startDate, Instant endDate) {
         return getEntityManager().createNativeQuery(SELECT_BY_NON_CATEGORY, AccountTransaction.class)
             .setParameter("userId", userId)
+            .setParameter("groupId", groupId)
             .setParameter("startDate", startDate)
             .setParameter("endDate", endDate)
             .getResultList();

--- a/rail-module/rail-service/src/main/java/com/hillayes/rail/repository/CategoryGroupRepository.java
+++ b/rail-module/rail-service/src/main/java/com/hillayes/rail/repository/CategoryGroupRepository.java
@@ -1,0 +1,76 @@
+package com.hillayes.rail.repository;
+
+import com.hillayes.commons.jpa.OrderBy;
+import com.hillayes.commons.jpa.Page;
+import com.hillayes.commons.jpa.RepositoryBase;
+import com.hillayes.rail.config.ServiceConfiguration;
+import com.hillayes.rail.domain.CategoryGroup;
+import com.hillayes.rail.domain.CategoryStatistics;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+@ApplicationScoped
+public class CategoryGroupRepository extends RepositoryBase<CategoryGroup, UUID> {
+    @Inject
+    ServiceConfiguration serviceConfiguration;
+
+    public void deleteByUserId(UUID userId) {
+        delete("userId", userId);
+    }
+
+    public Page<CategoryGroup> findByUserId(UUID userId, int page, int pageSize) {
+        return pageAll("userId = :userId", page, pageSize,
+            OrderBy.by("name"), Map.of("userId", userId));
+    }
+
+    public Optional<CategoryGroup> findByUserAndName(UUID userId, String name) {
+        return findFirst("userId = :userId and name = :name",
+            Map.of("userId", userId, "name", name));
+    }
+
+    /**
+     * Get the category statistics for the identified category group and date range.
+     * The result will be a list of {@link CategoryStatistics} instances, each
+     * representing a category, the number of transactions and the total value of
+     * transactions in that category. Any transactions that do match a category
+     * will be included in the "uncategorised" category.
+     *
+     * @param group The group for which to get statistics.
+     * @param startDate The start date (inclusive).
+     * @param endDate The end date (exclusive).
+     * @return The list of category statistics.
+     */
+    public List<CategoryStatistics> getStatistics(CategoryGroup group, Instant startDate, Instant endDate) {
+        String defaultName = serviceConfiguration.categories().uncategorisedName();
+        String defaultColour = serviceConfiguration.categories().defaultColour();
+
+        return getEntityManager().createNativeQuery("select " +
+                "coalesce (c.name, '" + defaultName + "') as category, " +
+                "c.id, c.description, " +
+                "coalesce (c.colour, '" + defaultColour + "') as colour, " +
+                "count(*) as count, sum(t.amount) / 100 as total, " +
+                "sum(case when t.amount > 0 then t.amount else 0 end) / 100 as credit, " +
+                "sum(case when t.amount < 0 then abs(t.amount) else 0 end) / 100 as debit " +
+                "from rails.account_transaction t " +
+                "left join rails.category_selector cs on cs.account_id = t.account_id and " +
+                "  (cs.info_contains is null or t.additional_information like concat('%', cs.info_contains, '%')) and " +
+                "  (cs.ref_contains is null or t.reference like concat('%', cs.ref_contains, '%')) and " +
+                "  (cs.creditor_contains is null or t.creditor_name like concat('%', cs.creditor_contains, '%')) " +
+                "left join rails.category c on c.group_id = :groupId and c.id = cs.category_id " +
+                "where t.user_id = :userId " +
+                "and t.booking_datetime >= :startDate " +
+                "and t.booking_datetime < :endDate " +
+                "group by 1, 2, 3, 4 order by 1", CategoryStatistics.class)
+            .setParameter("userId", group.getUserId())
+            .setParameter("groupId", group.getId())
+            .setParameter("startDate", startDate)
+            .setParameter("endDate", endDate)
+            .getResultList();
+    }
+}

--- a/rail-module/rail-service/src/main/java/com/hillayes/rail/repository/CategoryGroupRepository.java
+++ b/rail-module/rail-service/src/main/java/com/hillayes/rail/repository/CategoryGroupRepository.java
@@ -51,6 +51,8 @@ public class CategoryGroupRepository extends RepositoryBase<CategoryGroup, UUID>
         String defaultColour = serviceConfiguration.categories().defaultColour();
 
         return getEntityManager().createNativeQuery("select " +
+                ":groupId as group_id, " +
+                ":groupName as group_name, " +
                 "coalesce (c.name, '" + defaultName + "') as category, " +
                 "c.id, c.description, " +
                 "coalesce (c.colour, '" + defaultColour + "') as colour, " +
@@ -69,6 +71,7 @@ public class CategoryGroupRepository extends RepositoryBase<CategoryGroup, UUID>
                 "group by 1, 2, 3, 4 order by 1", CategoryStatistics.class)
             .setParameter("userId", group.getUserId())
             .setParameter("groupId", group.getId())
+            .setParameter("groupName", group.getName())
             .setParameter("startDate", startDate)
             .setParameter("endDate", endDate)
             .getResultList();

--- a/rail-module/rail-service/src/main/java/com/hillayes/rail/repository/CategoryRepository.java
+++ b/rail-module/rail-service/src/main/java/com/hillayes/rail/repository/CategoryRepository.java
@@ -3,72 +3,16 @@ package com.hillayes.rail.repository;
 import com.hillayes.commons.jpa.OrderBy;
 import com.hillayes.commons.jpa.Page;
 import com.hillayes.commons.jpa.RepositoryBase;
-import com.hillayes.rail.config.ServiceConfiguration;
 import com.hillayes.rail.domain.Category;
-import com.hillayes.rail.domain.CategoryStatistics;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.inject.Inject;
 
-import java.time.Instant;
-import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 
 @ApplicationScoped
 public class CategoryRepository extends RepositoryBase<Category, UUID> {
-    @Inject
-    ServiceConfiguration serviceConfiguration;
-
-    public void deleteByUserId(UUID userId) {
-        delete("userId", userId);
-    }
-
-    public Page<Category> findByUserId(UUID userId, int page, int pageSize) {
-        return pageAll("userId = :userId", page, pageSize,
-            OrderBy.by("name"), Map.of("userId", userId));
-    }
-
-    public Optional<Category> findByUserAndName(UUID userId, String name) {
-        return findFirst("userId = :userId and name = :name",
-            Map.of("userId", userId, "name", name));
-    }
-
-    /**
-     * Get the category statistics for the given user and date range. The result will be a list of
-     * {@link CategoryStatistics} instances, each representing a category, the number of transactions
-     * and the total value of transactions in that category. Any transactions that do match a category
-     * will be included in the "uncategorised" category.
-     *
-     * @param userId The user ID.
-     * @param startDate The start date (inclusive).
-     * @param endDate The end date (exclusive).
-     * @return The list of category statistics.
-     */
-    public List<CategoryStatistics> getStatistics(UUID userId, Instant startDate, Instant endDate) {
-        String defaultName = serviceConfiguration.categories().uncategorisedName();
-        String defaultColour = serviceConfiguration.categories().defaultColour();
-
-        return getEntityManager().createNativeQuery("select " +
-                "coalesce (c.name, '" + defaultName + "') as category, " +
-                "c.id, c.description, " +
-                "coalesce (c.colour, '" + defaultColour + "') as colour, " +
-                "count(*) as count, sum(t.amount) / 100 as total, " +
-                "sum(case when t.amount > 0 then t.amount else 0 end) / 100 as credit, " +
-                "sum(case when t.amount < 0 then abs(t.amount) else 0 end) / 100 as debit " +
-                "from rails.account_transaction t " +
-                "left join rails.category_selector cs on cs.account_id = t.account_id and " +
-                "  (cs.info_contains is null or t.additional_information like concat('%', cs.info_contains, '%')) and " +
-                "  (cs.ref_contains is null or t.reference like concat('%', cs.ref_contains, '%')) and " +
-                "  (cs.creditor_contains is null or t.creditor_name like concat('%', cs.creditor_contains, '%')) " +
-                "left join rails.category c on c.user_id = t.user_id and c.id = cs.category_id " +
-                "where t.user_id = :userId " +
-                "and t.booking_datetime >= :startDate " +
-                "and t.booking_datetime < :endDate " +
-                "group by 1, 2, 3, 4 order by 1", CategoryStatistics.class)
-            .setParameter("userId", userId)
-            .setParameter("startDate", startDate)
-            .setParameter("endDate", endDate)
-            .getResultList();
+    public Page<Category> findByGroupId(UUID groupId, int page, int pageSize) {
+        return pageAll("group.id = :groupId", page, pageSize,
+            OrderBy.by("name"), Map.of("groupId", groupId));
     }
 }

--- a/rail-module/rail-service/src/main/java/com/hillayes/rail/resource/AccountTransactionResource.java
+++ b/rail-module/rail-service/src/main/java/com/hillayes/rail/resource/AccountTransactionResource.java
@@ -100,14 +100,15 @@ public class AccountTransactionResource {
     }
 
     @GET
-    @Path("/category")
+    @Path("/{groupId}/category")
     public Response getTransactionsByCategory(@Context SecurityContext ctx,
+                                              @PathParam("groupId") UUID groupId,
                                               @QueryParam("category-id") UUID categoryId,
                                               @QueryParam("from-date") LocalDate fromDate,
                                               @QueryParam("to-date") LocalDate toDate) {
         UUID userId = AuthUtils.getUserId(ctx);
-        log.info("Getting transactions by category [userId: {}, categoryId: {}, from: {}, to: {}]",
-            userId, categoryId, fromDate, toDate);
+        log.info("Getting transactions by category [userId: {}, groupId: {}, categoryId: {}, from: {}, to: {}]",
+            userId, groupId, categoryId, fromDate, toDate);
 
         // convert dates to instant
         Instant startDate = (fromDate == null)
@@ -117,7 +118,8 @@ public class AccountTransactionResource {
             ? Instant.now().truncatedTo(ChronoUnit.DAYS)
             : toDate.atStartOfDay(ZoneOffset.UTC).toInstant();
 
-        List<TransactionResponse> result = accountTransactionService.findByCategory(userId, categoryId, startDate, endDate).stream()
+        List<TransactionResponse> result = accountTransactionService
+            .findByCategory(userId, groupId, categoryId, startDate, endDate).stream()
             .map(this::marshal)
             .toList();
         return Response.ok(result).build();

--- a/rail-module/rail-service/src/main/java/com/hillayes/rail/resource/CategoryResource.java
+++ b/rail-module/rail-service/src/main/java/com/hillayes/rail/resource/CategoryResource.java
@@ -86,7 +86,8 @@ public class CategoryResource {
             .path(CategoryResource.class)
             .path(CategoryResource.class, "getCategoryGroup")
             .buildFromMap(Map.of("groupId", group.getId()));
-        return Response.created(location).build();
+        return Response.created(location)
+            .entity(marshal(group)).build();
     }
 
     @PUT
@@ -98,10 +99,10 @@ public class CategoryResource {
         log.info("Updating category group [userId: {}, groupId: {}, group: {}]",
             userId, groupId, details.getName());
 
-        categoryService.updateCategoryGroup(userId, groupId,
+        CategoryGroup group = categoryService.updateCategoryGroup(userId, groupId,
             details.getName(), details.getDescription());
 
-        return Response.noContent().build();
+        return Response.ok(marshal(group)).build();
     }
 
     @DELETE
@@ -160,7 +161,8 @@ public class CategoryResource {
             .path(CategoryResource.class)
             .path(CategoryResource.class, "getCategory")
             .buildFromMap(Map.of("categoryId", category.getId()));
-        return Response.created(location).build();
+        return Response.created(location)
+            .entity(marshal(category)).build();
     }
 
     @GET
@@ -182,10 +184,10 @@ public class CategoryResource {
         UUID userId = AuthUtils.getUserId(ctx);
         log.info("Updating category [userId: {}, categoryId: {}, category: {}]", userId, categoryId, details.getName());
 
-        categoryService.updateCategory(userId, categoryId,
+        Category category = categoryService.updateCategory(userId, categoryId,
             details.getName(), details.getDescription(), details.getColour());
 
-        return Response.noContent().build();
+        return Response.ok(marshal(category)).build();
     }
 
     @DELETE
@@ -292,7 +294,9 @@ public class CategoryResource {
 
     private CategoryStatisticsResponse marshal(CategoryStatistics statistics) {
         return new CategoryStatisticsResponse()
-            .category(statistics.getCategory())
+            .groupId(statistics.getGroupId())
+            .groupName(statistics.getGroupName())
+            .categoryName(statistics.getCategory())
             .categoryId(statistics.getCategoryId())
             .description(statistics.getDescription())
             .colour(statistics.getColour())

--- a/rail-module/rail-service/src/main/java/com/hillayes/rail/resource/UserConsentResource.java
+++ b/rail-module/rail-service/src/main/java/com/hillayes/rail/resource/UserConsentResource.java
@@ -108,7 +108,7 @@ public class UserConsentResource {
         URI consentLink = userConsentService.register(userId, institutionId, consentRequest.getCallbackUri());
 
         log.debug("Redirecting user to bank consent [link: {}]", consentLink.toASCIIString());
-        return Response.ok(consentLink).build();
+        return Response.created(consentLink).build();
     }
 
     /**

--- a/rail-module/rail-service/src/main/java/com/hillayes/rail/service/AccountTransactionService.java
+++ b/rail-module/rail-service/src/main/java/com/hillayes/rail/service/AccountTransactionService.java
@@ -73,14 +73,14 @@ public class AccountTransactionService {
         return accountTransactionRepository.findTotals(filter);
     }
 
-    public List<AccountTransaction> findByCategory(UUID userId, UUID categoryId,
+    public List<AccountTransaction> findByCategory(UUID userId, UUID groupId, UUID categoryId,
                                                    Instant startDate, Instant endDate) {
         log.info("Get transactions by category [userId: {}, categoryId: {}, startDate: {}, endDate: {}]",
             userId, categoryId, startDate, endDate);
 
         List<AccountTransaction> result;
         if (categoryId == null) {
-            result = accountTransactionRepository.findUncategorised(userId, startDate, endDate);
+            result = accountTransactionRepository.findUncategorised(userId, groupId, startDate, endDate);
         } else {
             // ensure the category belongs to the user
             categoryService.getCategory(userId, categoryId);

--- a/rail-module/rail-service/src/main/java/com/hillayes/rail/service/CountryService.java
+++ b/rail-module/rail-service/src/main/java/com/hillayes/rail/service/CountryService.java
@@ -36,7 +36,7 @@ public class CountryService {
 
     public Optional<InputStream> getLogo(String id) {
         log.info("Get country logo [id: {}]", id);
-        Country country = get(id).orElseThrow(() -> new NotFoundException("country", id));
+        Country country = get(id).orElseThrow(() -> new NotFoundException("Country", id));
         if (country.getFlagUri() == null) {
             return Optional.empty();
         }

--- a/rail-module/rail-service/src/main/resources/db/migration/V1.0.2__category_groups.sql
+++ b/rail-module/rail-service/src/main/resources/db/migration/V1.0.2__category_groups.sql
@@ -1,0 +1,30 @@
+-- create a table to hold the uniquely named category groups
+CREATE TABLE ${flyway:defaultSchema}.category_group (
+    id uuid NOT NULL CONSTRAINT category_group_pkey PRIMARY KEY,
+    user_id UUID NOT NULL,
+    name varchar(256) NOT NULL,
+    description varchar(256) NULL,
+    version bigint NOT NULL DEFAULT 0
+);
+CREATE UNIQUE INDEX idx_category_group_name ON ${flyway:defaultSchema}.category_group (user_id, name);
+
+-- add a default group for each user
+INSERT INTO ${flyway:defaultSchema}.category_group (id, version, name, description, user_id)
+  VALUES(uuid_in(md5(random()::text || random()::text)::cstring), 0, 'Default', 'Default group', (SELECT DISTINCT c.user_id FROM ${flyway:defaultSchema}.category c));
+
+-- add a group_id column to the category table
+ALTER TABLE ${flyway:defaultSchema}.category ADD COLUMN group_id UUID NULL;
+
+-- update the category table to link to the default group
+UPDATE ${flyway:defaultSchema}.category SET group_id = g.id
+  FROM ${flyway:defaultSchema}.category c
+  JOIN ${flyway:defaultSchema}.category_group g ON g.user_id = c.user_id;
+
+-- make the group_id column not nullable
+ALTER TABLE ${flyway:defaultSchema}.category ALTER COLUMN group_id SET NOT NULL;
+
+-- add a foreign key constraint to the category table
+ALTER TABLE ${flyway:defaultSchema}.category
+  ADD CONSTRAINT fk_category_group
+  FOREIGN KEY (group_id)
+  REFERENCES ${flyway:defaultSchema}.category_group (id) ON DELETE CASCADE;

--- a/rail-module/rail-service/src/test/java/com/hillayes/rail/event/consumer/UserTopicConsumerTest.java
+++ b/rail-module/rail-service/src/test/java/com/hillayes/rail/event/consumer/UserTopicConsumerTest.java
@@ -52,7 +52,7 @@ public class UserTopicConsumerTest {
         // then: the consents for the deleted user are deleted
         verify(userConsentService).deleteAllConsents(userDeleted.getUserId());
 
-        // and: the categories for the deleted user are deleted
-        verify(categoryService).deleteAllCategories(userDeleted.getUserId());
+        // and: the category groups (and their categories) for the deleted user are deleted
+        verify(categoryService).deleteAllCategoryGroups(userDeleted.getUserId());
     }
 }

--- a/rail-module/rail-service/src/test/java/com/hillayes/rail/repository/CategoryGroupRepositoryTest.java
+++ b/rail-module/rail-service/src/test/java/com/hillayes/rail/repository/CategoryGroupRepositoryTest.java
@@ -1,0 +1,377 @@
+package com.hillayes.rail.repository;
+
+import com.hillayes.commons.MonetaryAmount;
+import com.hillayes.rail.domain.*;
+import com.hillayes.rail.utils.TestData;
+import io.quarkus.test.TestTransaction;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+@TestTransaction
+public class CategoryGroupRepositoryTest {
+    @Inject
+    UserConsentRepository userConsentRepository;
+
+    @Inject
+    AccountRepository accountRepository;
+
+    @Inject
+    AccountTransactionRepository accountTransactionRepository;
+
+    @Inject
+    CategoryGroupRepository fixture;
+
+    @Test
+    public void testSave() {
+        // given: a user-consent
+        UserConsent consent = userConsentRepository.save(mockUserConsent());
+
+        // when: persisting the category
+        CategoryGroup category = fixture.save(CategoryGroup.builder()
+            .userId(consent.getUserId())
+            .name(randomAlphanumeric(30))
+            .description(randomAlphanumeric(30))
+            .build());
+
+        fixture.flush();
+
+        // then: the category is persisted
+        assertNotNull(category.getId());
+    }
+
+    @Test
+    public void testSaveCategories() {
+        // given: a user-consent
+        UserConsent consent = userConsentRepository.save(mockUserConsent());
+
+        // and: a category
+        CategoryGroup categoryGroup = CategoryGroup.builder()
+            .userId(consent.getUserId())
+            .name(randomAlphanumeric(30))
+            .description(randomAlphanumeric(30))
+            .build();
+
+        // when: selectors are added
+        categoryGroup.addCategory(randomAlphanumeric(10), builder -> {
+            builder.description(randomAlphanumeric(20));
+            builder.colour("#FF0000");
+        });
+        categoryGroup.addCategory(randomAlphanumeric(10), builder -> {
+            builder.description(randomAlphanumeric(20));
+            builder.colour("#FF0001");
+        });
+        categoryGroup.addCategory(randomAlphanumeric(10), builder -> {
+            builder.description(randomAlphanumeric(20));
+            builder.colour("#FF0002");
+        });
+
+        Set<Category> categories = categoryGroup.getCategories();
+
+        // then: the selectors are linked to the category group
+        categories.forEach(category -> assertEquals(categoryGroup, category.getGroup()));
+
+        // when: the category is persisted
+        fixture.save(categoryGroup);
+        fixture.flush();
+        fixture.getEntityManager().clear();
+
+        // then: the selectors are persisted
+        categories.forEach(selector -> assertNotNull(selector.getId()));
+
+        // when: the category group is retrieved
+        CategoryGroup retrieved = fixture.findByIdOptional(categoryGroup.getId()).orElseThrow();
+
+        // then: the selectors are retrieved
+        assertEquals(categories.size(), retrieved.getCategories().size());
+    }
+
+    @Test
+    public void testDelete() {
+        // given: a user-consent
+        UserConsent consent = userConsentRepository.save(mockUserConsent());
+
+        // and: a category
+        CategoryGroup categoryGroup = CategoryGroup.builder()
+            .userId(consent.getUserId())
+            .name(randomAlphanumeric(30))
+            .description(randomAlphanumeric(30))
+            .build();
+
+        // when: categories are added to the category group
+        categoryGroup.addCategory(randomAlphanumeric(20), builder -> builder.description(randomAlphanumeric(20)));
+        categoryGroup.addCategory(randomAlphanumeric(20), builder -> builder.description(randomAlphanumeric(5)));
+        categoryGroup.addCategory(randomAlphanumeric(20), builder -> builder.description(randomAlphanumeric(10)));
+        Set<Category> categories = categoryGroup.getCategories();
+
+        // when: the category group is saved
+        fixture.save(categoryGroup);
+        fixture.flush();
+        fixture.getEntityManager().clear();
+
+        // then: all categories are saved
+        categories.forEach(category -> assertNotNull(category.getId()));
+
+        // when: the category group is deleted
+        fixture.delete(categoryGroup);
+        fixture.flush();
+        fixture.getEntityManager().clear();
+
+        // then: the category group is deleted
+        assertTrue(fixture.findByIdOptional(categoryGroup.getId()).isEmpty());
+
+        // and: all categories are deleted
+        assertEquals(0, fixture.getEntityManager()
+            .createNativeQuery("select count(*) from category where group_id = :groupId")
+            .setParameter("groupId", categoryGroup.getId())
+            .getFirstResult());
+    }
+
+    @Test
+    public void testFindByUserId() {
+        // given: a collection of user identities
+        List<UUID> userIds = List.of(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
+
+        // and: each user has a collection of category groups
+        Map<UUID, List<CategoryGroup>> userCategoryGroups = userIds.stream()
+            .flatMap(userId -> IntStream.range(0, 3).mapToObj(index ->
+                fixture.save(CategoryGroup.builder()
+                    .userId(userId)
+                    .name(randomAlphanumeric(30))
+                    .description(randomAlphanumeric(30))
+                    .build()))
+            )
+            .collect(Collectors.groupingBy(CategoryGroup::getUserId));
+
+        // and: the category groups are persisted
+        fixture.flush();
+        fixture.getEntityManager().clear();
+
+        // when: retrieving all category groups for each user
+        userIds.forEach(userId -> {
+            List<CategoryGroup> groups = fixture.findByUserId(userId, 0, 10).getContent();
+
+            // then: the categories are retrieved
+            assertEquals(userCategoryGroups.get(userId).size(), groups.size());
+            userCategoryGroups.get(userId).forEach(category -> assertTrue(groups.contains(category)));
+        });
+    }
+
+    @Test
+    public void testFindByUserIdPaged() {
+        // given: a user identity
+        UUID userId = UUID.randomUUID();
+
+        // and: the user has a collection of categories
+        List<CategoryGroup> userCategoryGroups = IntStream.range(0, 30)
+            .mapToObj(index ->
+                CategoryGroup.builder()
+                    .userId(userId)
+                    .name(randomAlphanumeric(30))
+                    .description(randomAlphanumeric(30))
+                    .build()
+            )
+            .sorted(Comparator.comparing(CategoryGroup::getName, String::compareToIgnoreCase))
+            .toList();
+
+        // and: the categories are persisted
+        fixture.saveAll(userCategoryGroups);
+        fixture.flush();
+        fixture.getEntityManager().clear();
+
+        // when: retrieving categories by page
+        int pageSize = 10;
+        int pageCount = 3;
+        for (int page = 0; page < pageCount; page++) {
+            List<CategoryGroup> categoryGroups = fixture.findByUserId(userId, page, pageSize).getContent();
+
+            // then: the category groups are retrieved for that page
+            assertEquals(pageSize, categoryGroups.size());
+            assertEquals(userCategoryGroups.subList(page * pageSize, (page + 1) * pageSize), categoryGroups);
+        }
+    }
+
+    @Test
+    public void testFindByUserAndName() {
+        // given: a user-consent
+        UserConsent consent = userConsentRepository.save(mockUserConsent());
+
+        // and: several categories
+        List<CategoryGroup> categoryGroups = IntStream.range(0, 5).mapToObj(index ->
+            fixture.save(CategoryGroup.builder()
+                .userId(consent.getUserId())
+                .name(randomAlphanumeric(30))
+                .description(randomAlphanumeric(30))
+                .build())
+        ).toList();
+
+        fixture.flush();
+        fixture.getEntityManager().clear();
+
+        // when: retrieving each category by user and name
+        categoryGroups.forEach(categoryGroup -> {
+            Optional<CategoryGroup> result = fixture.findByUserAndName(consent.getUserId(), categoryGroup.getName());
+
+            // then: the named category is retrieved
+            assertTrue(result.isPresent());
+            assertEquals(categoryGroup.getId(), result.get().getId());
+        });
+    }
+
+    @Test
+    public void testDeleteByUserId() {
+        // given: a collection of user identities
+        List<UUID> userIds = List.of(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
+
+        // and: each user has a collection of category groups
+        Map<UUID, List<CategoryGroup>> userCategories = userIds.stream()
+            .flatMap(userId -> IntStream.range(0, 3).mapToObj(index ->
+                fixture.save(CategoryGroup.builder()
+                    .userId(userId)
+                    .name(randomAlphanumeric(30))
+                    .description(randomAlphanumeric(30))
+                    .build()))
+            )
+            .collect(Collectors.groupingBy(CategoryGroup::getUserId));
+
+        // and: the category groups are persisted
+        fixture.flush();
+        fixture.getEntityManager().clear();
+        userIds.forEach(userId ->
+            userCategories.get(userId)
+                .forEach(category -> assertTrue(fixture.findByIdOptional(category.getId()).isPresent()))
+        );
+
+        // when: deleting all category groups for user #2
+        fixture.deleteByUserId(userIds.get(1));
+        fixture.flush();
+        fixture.getEntityManager().clear();
+
+        // then: the category groups for user #2 are deleted
+        userCategories.get(userIds.get(1))
+            .forEach(group -> assertTrue(fixture.findByIdOptional(group.getId()).isEmpty()));
+
+        // and: the category groups for user #1 are not deleted
+        userCategories.get(userIds.get(0))
+            .forEach(group -> assertTrue(fixture.findByIdOptional(group.getId()).isPresent()));
+
+        // and: the category groups for user #3 are not deleted
+        userCategories.get(userIds.get(2))
+            .forEach(group -> assertTrue(fixture.findByIdOptional(group.getId()).isPresent()));
+    }
+
+    @Test
+    public void testGetStatistics() {
+        Instant now = Instant.now().truncatedTo(ChronoUnit.DAYS);
+
+        // given: a user-consent
+        UserConsent consent = userConsentRepository.save(mockUserConsent());
+
+        // and: a linked account
+        Account account = accountRepository.save(mockAccount(consent));
+
+        // and: a category group
+        CategoryGroup categoryGroup = CategoryGroup.builder()
+            .userId(consent.getUserId())
+            .name("group 1")
+            .description("desc 1")
+            .build();
+
+        // and: a collection of categories with selectors for the account's transactions
+        List<Category> categories = List.of(
+            categoryGroup.addCategory("category 1", builder -> builder.description("desc 1").colour("#111111").build())
+                .addSelector(account.getId(), builder -> builder.infoContains("info 1").build()),
+            categoryGroup.addCategory("category 2", builder -> builder.description("desc 2").colour("#222222").build())
+                .addSelector(account.getId(), builder -> builder.refContains("info 2").build()),
+            categoryGroup.addCategory("category 3", builder -> builder.description("desc 3").colour("#333333").build())
+                .addSelector(account.getId(), builder -> builder.creditorContains("info 3").build()),
+            categoryGroup.addCategory("category 4", builder -> builder.description("desc 4").colour("#444444").build())
+                .addSelector(account.getId(), builder -> builder.infoContains("info 4").build())
+        );
+
+        fixture.save(categoryGroup);
+
+        // and: a collection of transactions for the account
+        // and: a match for each selector
+        // and: one that doesn't match the selectors
+        accountTransactionRepository.saveAll(List.of(
+            TestData.mockAccountTransaction(account, transaction ->
+                transaction.id(null)
+                    .bookingDateTime(now.minus(Duration.ofDays(7)))
+                    .additionalInformation("contains info 1 text")
+                    .amount(MonetaryAmount.of("GBP", 100))
+            ),
+            TestData.mockAccountTransaction(account, transaction ->
+                transaction.id(null)
+                    .bookingDateTime(now.minus(Duration.ofDays(6)))
+                    .reference("contains info 2 text")
+                    .amount(MonetaryAmount.of("GBP", 200))
+            ),
+            TestData.mockAccountTransaction(account, transaction ->
+                transaction.id(null)
+                    .bookingDateTime(now.minus(Duration.ofDays(5)))
+                    .creditorName("contains info 3 text")
+                    .amount(MonetaryAmount.of("GBP", 300))
+            ),
+            TestData.mockAccountTransaction(account, transaction ->
+                transaction.id(null)
+                    .bookingDateTime(now.minus(Duration.ofDays(4)))
+                    .additionalInformation("contains info 4 text")
+                    .amount(MonetaryAmount.of("GBP", 400))
+            ),
+            TestData.mockAccountTransaction(account, transaction ->
+                transaction.id(null)
+                    .bookingDateTime(now.minus(Duration.ofDays(3)))
+                    .additionalInformation("contains uncategorised text")
+                    .amount(MonetaryAmount.of("GBP", 500))
+            )
+        ));
+        fixture.flush();
+
+        // when: the statistics are retrieved
+        List<CategoryStatistics> statistics =
+            fixture.getStatistics(categoryGroup, now.minus(Duration.ofDays(7)), now);
+
+        // then: the statistics are retrieved
+        assertEquals(5, statistics.size());
+
+        // and: the statistics are correct
+        categories.forEach(category -> {
+            CategoryStatistics projection = statistics.stream()
+                .filter(stat -> stat.getCategory().equals(category.getName()))
+                .findFirst()
+                .orElseThrow();
+
+            assertEquals(category.getId(), projection.getCategoryId());
+            assertEquals(1, projection.getCount());
+        });
+
+        // and: the uncategorised statistic is correct
+        statistics.stream().filter(stat -> stat.getCategoryId() == null).findFirst().ifPresent(stat ->
+            assertEquals(5.00, stat.getTotal().doubleValue())
+        );
+    }
+
+    private UserConsent mockUserConsent() {
+        return TestData.mockUserConsent(UUID.randomUUID(), consent -> consent.id(null));
+    }
+
+    private Account mockAccount(UserConsent consent) {
+        return TestData.mockAccount(consent.getUserId(), account -> {
+            account.id(null);
+            account.userConsentId(consent.getId());
+            account.institutionId(consent.getInstitutionId());
+        });
+    }
+}

--- a/rail-module/rail-service/src/test/java/com/hillayes/rail/repository/CategoryGroupRepositoryTest.java
+++ b/rail-module/rail-service/src/test/java/com/hillayes/rail/repository/CategoryGroupRepositoryTest.java
@@ -353,6 +353,8 @@ public class CategoryGroupRepositoryTest {
                 .findFirst()
                 .orElseThrow();
 
+            assertEquals(categoryGroup.getId(), projection.getGroupId());
+            assertEquals(categoryGroup.getName(), projection.getGroupName());
             assertEquals(category.getId(), projection.getCategoryId());
             assertEquals(1, projection.getCount());
         });

--- a/rail-module/rail-service/src/test/java/com/hillayes/rail/repository/CategoryRepositoryTest.java
+++ b/rail-module/rail-service/src/test/java/com/hillayes/rail/repository/CategoryRepositoryTest.java
@@ -1,6 +1,5 @@
 package com.hillayes.rail.repository;
 
-import com.hillayes.commons.MonetaryAmount;
 import com.hillayes.rail.domain.*;
 import com.hillayes.rail.utils.TestData;
 import io.quarkus.test.TestTransaction;
@@ -8,11 +7,10 @@ import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
-import java.time.Duration;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 import java.util.stream.IntStream;
 
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
@@ -28,7 +26,7 @@ public class CategoryRepositoryTest {
     AccountRepository accountRepository;
 
     @Inject
-    AccountTransactionRepository accountTransactionRepository;
+    CategoryGroupRepository categoryGroupRepository;
 
     @Inject
     CategoryRepository fixture;
@@ -38,9 +36,16 @@ public class CategoryRepositoryTest {
         // given: a user-consent
         UserConsent consent = userConsentRepository.save(mockUserConsent());
 
+        // and: a category group for the user
+        CategoryGroup categoryGroup = categoryGroupRepository.save(CategoryGroup.builder()
+            .userId(consent.getUserId())
+            .name(randomAlphanumeric(30))
+            .description(randomAlphanumeric(30))
+            .build());
+
         // when: persisting the category
         Category category = fixture.save(Category.builder()
-            .userId(consent.getUserId())
+            .group(categoryGroup)
             .name(randomAlphanumeric(30))
             .description(randomAlphanumeric(30))
             .colour("#FF0000")
@@ -60,29 +65,36 @@ public class CategoryRepositoryTest {
         // and: a linked account
         Account account = accountRepository.save(mockAccount(consent));
 
+        // and: a category group for the user
+        CategoryGroup categoryGroup = categoryGroupRepository.save(CategoryGroup.builder()
+            .userId(consent.getUserId())
+            .name(randomAlphanumeric(30))
+            .description(randomAlphanumeric(30))
+            .build());
+
         // and: a category
         Category category = Category.builder()
-            .userId(consent.getUserId())
+            .group(categoryGroup)
             .name(randomAlphanumeric(30))
             .description(randomAlphanumeric(30))
             .colour("#FF0000")
             .build();
 
         // when: selectors are added
-            category.addSelector(account.getId(), builder -> {
-                builder.infoContains(randomAlphanumeric(10));
-                builder.refContains(randomAlphanumeric(20));
-                builder.creditorContains(randomAlphanumeric(15));
-            });
-            category.addSelector(account.getId(), builder ->
-                builder.infoContains(randomAlphanumeric(12))
-            );
-            category.addSelector(account.getId(), builder ->
-                builder.refContains(randomAlphanumeric(25))
-            );
-            category.addSelector(account.getId(), builder ->
-                builder.creditorContains(randomAlphanumeric(10))
-            );
+        category.addSelector(account.getId(), builder -> {
+            builder.infoContains(randomAlphanumeric(10));
+            builder.refContains(randomAlphanumeric(20));
+            builder.creditorContains(randomAlphanumeric(15));
+        });
+        category.addSelector(account.getId(), builder ->
+            builder.infoContains(randomAlphanumeric(12))
+        );
+        category.addSelector(account.getId(), builder ->
+            builder.refContains(randomAlphanumeric(25))
+        );
+        category.addSelector(account.getId(), builder ->
+            builder.creditorContains(randomAlphanumeric(10))
+        );
         Set<CategorySelector> selectors = category.getSelectors();
 
         // then: the selectors are linked to the category
@@ -114,9 +126,16 @@ public class CategoryRepositoryTest {
         // and: a linked account
         Account account = accountRepository.save(mockAccount(consent));
 
+        // and: a category group for the user
+        CategoryGroup categoryGroup = categoryGroupRepository.save(CategoryGroup.builder()
+            .userId(consent.getUserId())
+            .name(randomAlphanumeric(30))
+            .description(randomAlphanumeric(30))
+            .build());
+
         // and: a category
         Category category = Category.builder()
-            .userId(consent.getUserId())
+            .group(categoryGroup)
             .name(randomAlphanumeric(30))
             .description(randomAlphanumeric(30))
             .colour("#FF0000")
@@ -152,46 +171,22 @@ public class CategoryRepositoryTest {
     }
 
     @Test
-    public void testFindByUserId() {
-        // given: a collection of user identities
-        List<UUID> userIds = List.of(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
-
-        // and: each user has a collection of categories
-        Map<UUID, List<Category>> userCategories = userIds.stream()
-            .flatMap(userId -> IntStream.range(0, 3).mapToObj(index ->
-                fixture.save(Category.builder()
-                    .userId(userId)
-                    .name(randomAlphanumeric(30))
-                    .description(randomAlphanumeric(30))
-                    .colour("#FF0000")
-                    .build()))
-            )
-            .collect(Collectors.groupingBy(Category::getUserId));
-
-        // and: the categories are persisted
-        fixture.flush();
-        fixture.getEntityManager().clear();
-
-        // when: retrieving all categories for each user
-        userIds.forEach(userId -> {
-            List<Category> categories = fixture.findByUserId(userId, 0, 10).getContent();
-
-            // then: the categories are retrieved
-            assertEquals(userCategories.get(userId).size(), categories.size());
-            userCategories.get(userId).forEach(category -> assertTrue(categories.contains(category)));
-        });
-    }
-
-    @Test
-    public void testFindByUserIdPaged() {
+    public void testFindByGroupIdPaged() {
         // given: a user identity
         UUID userId = UUID.randomUUID();
 
-        // and: the user has a collection of categories
+        // and: a category group for the user
+        CategoryGroup categoryGroup = categoryGroupRepository.save(CategoryGroup.builder()
+            .userId(userId)
+            .name(randomAlphanumeric(30))
+            .description(randomAlphanumeric(30))
+            .build());
+
+        // and: the group has a collection of categories
         List<Category> userCategories = IntStream.range(0, 30)
             .mapToObj(index ->
                 Category.builder()
-                    .userId(userId)
+                    .group(categoryGroup)
                     .name(randomAlphanumeric(30))
                     .description(randomAlphanumeric(30))
                     .colour("#FF0000")
@@ -209,167 +204,12 @@ public class CategoryRepositoryTest {
         int pageSize = 10;
         int pageCount = 3;
         for (int page = 0; page < pageCount; page++) {
-            List<Category> categories = fixture.findByUserId(userId, page, pageSize).getContent();
+            List<Category> categories = fixture.findByGroupId(categoryGroup.getId(), page, pageSize).getContent();
 
             // then: the categories are retrieved for that page
             assertEquals(pageSize, categories.size());
             assertEquals(userCategories.subList(page * pageSize, (page + 1) * pageSize), categories);
         }
-    }
-
-    @Test
-    public void testFindByUserAndName() {
-        // given: a user-consent
-        UserConsent consent = userConsentRepository.save(mockUserConsent());
-
-        // and: several categories
-        List<Category> categories = IntStream.range(0, 5).mapToObj(index ->
-            fixture.save(Category.builder()
-                .userId(consent.getUserId())
-                .name(randomAlphanumeric(30))
-                .description(randomAlphanumeric(30))
-                .colour("#FF0000")
-                .build())
-        ).toList();
-
-        fixture.flush();
-        fixture.getEntityManager().clear();
-
-        // when: retrieving each category by user and name
-        categories.forEach(category -> {
-            Optional<Category> result = fixture.findByUserAndName(consent.getUserId(), category.getName());
-
-            // then: the named category is retrieved
-            assertTrue(result.isPresent());
-            assertEquals(category.getId(), result.get().getId());
-        });
-    }
-
-    @Test
-    public void testDeleteByUserId() {
-        // given: a collection of user identities
-        List<UUID> userIds = List.of(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
-
-        // and: each user has a collection of categories
-        Map<UUID, List<Category>> userCategories = userIds.stream()
-            .flatMap(userId -> IntStream.range(0, 3).mapToObj(index ->
-                fixture.save(Category.builder()
-                    .userId(userId)
-                    .name(randomAlphanumeric(30))
-                    .description(randomAlphanumeric(30))
-                    .colour("#FF0000")
-                    .build()))
-            )
-            .collect(Collectors.groupingBy(Category::getUserId));
-
-        // and: the categories are persisted
-        fixture.flush();
-        fixture.getEntityManager().clear();
-        userIds.forEach(userId ->
-            userCategories.get(userId)
-                .forEach(category -> assertTrue(fixture.findByIdOptional(category.getId()).isPresent()))
-        );
-
-        // when: deleting all categories for user #2
-        fixture.deleteByUserId(userIds.get(1));
-        fixture.flush();
-        fixture.getEntityManager().clear();
-
-        // then: the categories for user #2 are deleted
-        userCategories.get(userIds.get(1))
-            .forEach(category -> assertTrue(fixture.findByIdOptional(category.getId()).isEmpty()));
-
-        // and: the categories for user #1 are not deleted
-        userCategories.get(userIds.get(0))
-            .forEach(category -> assertTrue(fixture.findByIdOptional(category.getId()).isPresent()));
-
-        // and: the categories for user #3 are not deleted
-        userCategories.get(userIds.get(2))
-            .forEach(category -> assertTrue(fixture.findByIdOptional(category.getId()).isPresent()));
-    }
-
-    @Test
-    public void testGetStatistics() {
-        Instant now = Instant.now().truncatedTo(ChronoUnit.DAYS);
-
-        // given: a user-consent
-        UserConsent consent = userConsentRepository.save(mockUserConsent());
-
-        // and: a linked account
-        Account account = accountRepository.save(mockAccount(consent));
-
-        // and: a collection of categories with selectors for the account's transactions
-        List<Category> categories = List.of(
-            Category.builder().userId(consent.getUserId()).name("category 1").description("desc 1").colour("#111111").build()
-                .addSelector(account.getId(), builder -> builder.infoContains("info 1").build()),
-            Category.builder().userId(consent.getUserId()).name("category 2").description("desc 2").colour("#222222").build()
-                .addSelector(account.getId(), builder -> builder.refContains("info 2").build()),
-            Category.builder().userId(consent.getUserId()).name("category 3").description("desc 3").colour("#333333").build()
-                .addSelector(account.getId(), builder -> builder.creditorContains("info 3").build()),
-            Category.builder().userId(consent.getUserId()).name("category 4").description("desc 4").colour("#444444").build()
-                .addSelector(account.getId(), builder -> builder.infoContains("info 4").build())
-        );
-        fixture.saveAll(categories);
-
-        // and: a collection of transactions for the account
-        // and: a match for each selector
-        // and: one that doesn't match the selectors
-        accountTransactionRepository.saveAll(List.of(
-            TestData.mockAccountTransaction(account, transaction ->
-                transaction.id(null)
-                    .bookingDateTime(now.minus(Duration.ofDays(7)))
-                    .additionalInformation("contains info 1 text")
-                    .amount(MonetaryAmount.of("GBP", 100))
-            ),
-            TestData.mockAccountTransaction(account, transaction ->
-                transaction.id(null)
-                    .bookingDateTime(now.minus(Duration.ofDays(6)))
-                    .reference("contains info 2 text")
-                    .amount(MonetaryAmount.of("GBP", 200))
-            ),
-            TestData.mockAccountTransaction(account, transaction ->
-                transaction.id(null)
-                    .bookingDateTime(now.minus(Duration.ofDays(5)))
-                    .creditorName("contains info 3 text")
-                    .amount(MonetaryAmount.of("GBP", 300))
-            ),
-            TestData.mockAccountTransaction(account, transaction ->
-                transaction.id(null)
-                    .bookingDateTime(now.minus(Duration.ofDays(4)))
-                    .additionalInformation("contains info 4 text")
-                    .amount(MonetaryAmount.of("GBP", 400))
-            ),
-            TestData.mockAccountTransaction(account, transaction ->
-                transaction.id(null)
-                    .bookingDateTime(now.minus(Duration.ofDays(3)))
-                    .additionalInformation("contains uncategorised text")
-                    .amount(MonetaryAmount.of("GBP", 500))
-            )
-        ));
-        fixture.flush();
-
-        // when: the statistics are retrieved
-        List<CategoryStatistics> statistics =
-            fixture.getStatistics(consent.getUserId(), now.minus(Duration.ofDays(7)), now);
-
-        // then: the statistics are retrieved
-        assertEquals(5, statistics.size());
-
-        // and: the statistics are correct
-        categories.forEach(category -> {
-            CategoryStatistics projection = statistics.stream()
-                .filter(stat -> stat.getCategory().equals(category.getName()))
-                .findFirst()
-                .orElseThrow();
-
-            assertEquals(category.getId(), projection.getCategoryId());
-            assertEquals(1, projection.getCount());
-        });
-
-        // and: the uncategorised statistic is correct
-        statistics.stream().filter(stat -> stat.getCategoryId() == null).findFirst().ifPresent(stat ->
-            assertEquals(5.00, stat.getTotal().doubleValue())
-        );
     }
 
     private UserConsent mockUserConsent() {

--- a/rail-module/rail-service/src/test/java/com/hillayes/rail/resource/CategoryResourceTest.java
+++ b/rail-module/rail-service/src/test/java/com/hillayes/rail/resource/CategoryResourceTest.java
@@ -3,6 +3,7 @@ package com.hillayes.rail.resource;
 import com.hillayes.commons.jpa.Page;
 import com.hillayes.onestop.api.*;
 import com.hillayes.rail.domain.Category;
+import com.hillayes.rail.domain.CategoryGroup;
 import com.hillayes.rail.domain.CategorySelector;
 import com.hillayes.rail.domain.CategoryStatistics;
 import com.hillayes.rail.service.CategoryService;
@@ -36,7 +37,7 @@ public class CategoryResourceTest extends TestBase {
 
     @Test
     @TestSecurity(user = userIdStr, roles = "user")
-    public void testGetCategories() {
+    public void testGetCategoryGroups() {
         // given: an authenticated user
         UUID userId = UUID.fromString(userIdStr);
 
@@ -44,27 +45,204 @@ public class CategoryResourceTest extends TestBase {
         int page = 2;
         int pageSize = 19;
 
-        // and: a paginated list of categories
-        Page<Category> categories = Page.of(mockCategories(40), page, pageSize);
-        when(categoryService.getCategories(userId, page, pageSize))
-            .thenReturn(categories);
+        // and: a paginated list of category groups
+        Page<CategoryGroup> groups = Page.of(mockCategoryGroups(userId, 40), page, pageSize);
+        when(categoryService.getCategoryGroups(userId, page, pageSize))
+            .thenReturn(groups);
 
-        // when: a paginated list of categories is requested
-        PaginatedCategories response = given()
+        // when: a paginated list of category groups is requested
+        PaginatedCategoryGroups response = given()
             .request()
             .queryParam("page", page)
             .queryParam("page-size", pageSize)
             .contentType(JSON)
             .when()
-            .get("/api/v1/rails/categories")
+            .get("/api/v1/rails/category-groups")
+            .then()
+            .statusCode(200)
+            .contentType(JSON)
+            .extract()
+            .as(PaginatedCategoryGroups.class);
+
+        // then: the category-service is called with the authenticated user-id and page
+        verify(categoryService).getCategoryGroups(userId, page, pageSize);
+
+        // and: the response contains the paginated list of category groups
+        assertEquals(page, response.getPage());
+        assertEquals(pageSize, response.getPageSize());
+        assertEquals(groups.getContentSize(), response.getCount());
+        assertEquals(groups.getTotalCount(), response.getTotal());
+        assertEquals(groups.getTotalPages(), response.getTotalPages());
+
+        // and: the page links contain given filter properties
+        PageLinks links = response.getLinks();
+        assertTrue(links.getFirst().getQuery().contains("page=0"));
+        assertTrue(links.getFirst().getQuery().contains("page-size=" + pageSize));
+    }
+
+    @Test
+    @TestSecurity(user = userIdStr, roles = "user")
+    public void testGetCategoryGroup() {
+        // given: an authenticated user
+        UUID userId = UUID.fromString(userIdStr);
+
+        // and: an existing category group
+        CategoryGroup group = mockCategoryGroup(userId, randomAlphanumeric(20));
+
+        // when: a category group is requested
+        CategoryGroupResponse response = given()
+            .request()
+            .pathParam("groupId", group.getId())
+            .contentType(JSON)
+            .when()
+            .get("/api/v1/rails/category-groups/{groupId}")
+            .then()
+            .statusCode(200)
+            .contentType(JSON)
+            .extract()
+            .as(CategoryGroupResponse.class);
+
+        // then: the response contains the requested category group
+        assertEquals(group.getId(), response.getId());
+        assertEquals(group.getName(), response.getName());
+        assertEquals(group.getDescription(), response.getDescription());
+    }
+
+    @Test
+    @TestSecurity(user = userIdStr, roles = "user")
+    public void testCreateCategoryGroup() {
+        // given: an authenticated user
+        UUID userId = UUID.fromString(userIdStr);
+
+        // and: a new category group request
+        CategoryGroupRequest request = new CategoryGroupRequest()
+            .name(randomAlphanumeric(20))
+            .description(randomAlphanumeric(20));
+
+        // and: the service is mocked to return the new category group
+        CategoryGroup group = CategoryGroup.builder()
+            .id(UUID.randomUUID())
+            .name(request.getName())
+            .description(request.getDescription()).build();
+        when(categoryService.createCategoryGroup(userId, request.getName(), request.getDescription()))
+            .thenReturn(group);
+
+        // when: a new category is created
+        String location = given()
+            .request()
+            .contentType(JSON)
+            .body(request)
+            .when()
+            .post("/api/v1/rails/category-groups")
+            .then()
+            .statusCode(201)
+            .extract().header("Location");
+
+        // then: the category-service is called with the authenticated user-id and new category group details
+        verify(categoryService).createCategoryGroup(userId, request.getName(), request.getDescription());
+
+        // and: the new category group locator is returned
+        assertTrue(location.contains("/api/v1/rails/category-groups/" + group.getId().toString()));
+    }
+
+    @Test
+    @TestSecurity(user = userIdStr, roles = "user")
+    public void testUpdateCategoryGroup() {
+        // given: an authenticated user
+        UUID userId = UUID.fromString(userIdStr);
+
+        // and: a category group update request
+        CategoryGroupRequest request = new CategoryGroupRequest()
+            .name(randomAlphanumeric(20))
+            .description(randomAlphanumeric(20));
+
+        // and: a category group to be updated
+        CategoryGroup group = CategoryGroup.builder()
+            .id(UUID.randomUUID())
+            .name(request.getName())
+            .description(request.getDescription()).build();
+        when(categoryService.updateCategoryGroup(userId, group.getId(), request.getName(), request.getDescription()))
+            .thenReturn(group);
+
+        // when: the category is updated
+        given()
+            .request()
+            .pathParam("groupId", group.getId())
+            .contentType(JSON)
+            .body(request)
+            .when()
+            .put("/api/v1/rails/category-groups/{groupId}")
+            .then()
+            .statusCode(204);
+
+        // then: the category-service is called with the authenticated user-id and updated category group details
+        verify(categoryService).updateCategoryGroup(userId, group.getId(),
+            request.getName(), request.getDescription());
+    }
+
+    @Test
+    @TestSecurity(user = userIdStr, roles = "user")
+    public void testDeleteCategoryGroup() {
+        // given: an authenticated user
+        UUID userId = UUID.fromString(userIdStr);
+
+        // and: a category group belonging to the user
+        CategoryGroup group = CategoryGroup.builder()
+            .id(UUID.randomUUID())
+            .name(randomAlphanumeric(20))
+            .description(randomAlphanumeric(20)).build();
+        when(categoryService.deleteCategoryGroup(userId, group.getId()))
+            .thenReturn(group);
+
+        // when: the category is deleted
+        given()
+            .request()
+            .pathParam("groupId", group.getId())
+            .contentType(JSON)
+            .when()
+            .delete("/api/v1/rails/category-groups/{groupId}")
+            .then()
+            .statusCode(204);
+
+        // then: the category-service is called with the authenticated user-id and group id
+        verify(categoryService).deleteCategoryGroup(userId, group.getId());
+    }
+
+    @Test
+    @TestSecurity(user = userIdStr, roles = "user")
+    public void testGetCategories() {
+        // given: an authenticated user
+        UUID userId = UUID.fromString(userIdStr);
+
+        // and: a category group belonging to the user
+        CategoryGroup group = mockCategoryGroup(userId, randomAlphanumeric(20));
+
+        // and: a page range
+        int page = 2;
+        int pageSize = 19;
+
+        // and: a paginated list of categories
+        Page<Category> categories = Page.of(mockCategories(group, 40), page, pageSize);
+        when(categoryService.getCategories(userId, group.getId(), page, pageSize))
+            .thenReturn(categories);
+
+        // when: a paginated list of categories is requested
+        PaginatedCategories response = given()
+            .request()
+            .pathParam("groupId", group.getId())
+            .queryParam("page", page)
+            .queryParam("page-size", pageSize)
+            .contentType(JSON)
+            .when()
+            .get("/api/v1/rails/category-groups/{groupId}/categories")
             .then()
             .statusCode(200)
             .contentType(JSON)
             .extract()
             .as(PaginatedCategories.class);
 
-        // then: the category-service is called with the authenticated user-id and page
-        verify(categoryService).getCategories(userId, page, pageSize);
+        // then: the category-service is called with the authenticated user-id, group-id and page
+        verify(categoryService).getCategories(userId, group.getId(), page, pageSize);
 
         // and: the response contains the paginated list of categories
         assertEquals(page, response.getPage());
@@ -85,10 +263,11 @@ public class CategoryResourceTest extends TestBase {
         // given: an authenticated user
         UUID userId = UUID.fromString(userIdStr);
 
+        // and: a category group belonging to the user
+        CategoryGroup group = mockCategoryGroup(userId, randomAlphanumeric(20));
+
         // and: an existing category
-        Category category = mockCategory(randomAlphanumeric(20));
-        when(categoryService.getCategory(userId, category.getId()))
-            .thenReturn(category);
+        Category category = mockCategory(group, randomAlphanumeric(20));
 
         // when: a category is requested
         CategoryResponse response = given()
@@ -105,6 +284,7 @@ public class CategoryResourceTest extends TestBase {
 
         // then: the response contains the requested category
         assertEquals(category.getId(), response.getId());
+        assertEquals(category.getGroup().getId(), response.getGroupId());
         assertEquals(category.getName(), response.getName());
         assertEquals(category.getDescription(), response.getDescription());
         assertEquals(category.getColour(), response.getColour());
@@ -115,6 +295,9 @@ public class CategoryResourceTest extends TestBase {
     public void testCreateCategory() {
         // given: an authenticated user
         UUID userId = UUID.fromString(userIdStr);
+
+        // and: a category group ID
+        UUID groupId = UUID.randomUUID();
 
         // and: a new category request
         CategoryRequest request = new CategoryRequest()
@@ -128,7 +311,7 @@ public class CategoryResourceTest extends TestBase {
             .name(request.getName())
             .description(request.getDescription())
             .colour(request.getColour()).build();
-        when(categoryService.createCategory(userId, request.getName(), request.getDescription(), request.getColour()))
+        when(categoryService.createCategory(userId, groupId, request.getName(), request.getDescription(), request.getColour()))
             .thenReturn(category);
 
         // when: a new category is created
@@ -136,14 +319,15 @@ public class CategoryResourceTest extends TestBase {
             .request()
             .contentType(JSON)
             .body(request)
+            .pathParam("groupId", groupId)
             .when()
-            .post("/api/v1/rails/categories")
+            .post("/api/v1/rails/category-groups/{groupId}/categories")
             .then()
             .statusCode(201)
             .extract().header("Location");
 
-        // then: the category-service is called with the authenticated user-id and new category details
-        verify(categoryService).createCategory(userId, request.getName(), request.getDescription(), request.getColour());
+        // then: the category-service is called with the authenticated user-id, group-id and new category details
+        verify(categoryService).createCategory(userId, groupId, request.getName(), request.getDescription(), request.getColour());
 
         // and: the new category locator is returned
         assertTrue(location.contains("/api/v1/rails/categories/" + category.getId().toString()));
@@ -161,16 +345,16 @@ public class CategoryResourceTest extends TestBase {
             .description(randomAlphanumeric(20))
             .colour(randomAlphanumeric(20));
 
-        // and: the service is mocked to return the new category
+        // and: a category to be updated
         Category category = Category.builder()
             .id(UUID.randomUUID())
             .name(request.getName())
             .description(request.getDescription())
             .colour(request.getColour()).build();
-        when(categoryService.createCategory(userId, request.getName(), request.getDescription(), request.getColour()))
+        when(categoryService.updateCategory(userId, category.getId(), request.getName(), request.getDescription(), request.getColour()))
             .thenReturn(category);
 
-        // when: a new category is created
+        // when: the category is updated
         given()
             .request()
             .pathParam("categoryId", category.getId())
@@ -184,6 +368,34 @@ public class CategoryResourceTest extends TestBase {
         // then: the category-service is called with the authenticated user-id and updated category details
         verify(categoryService).updateCategory(userId, category.getId(),
             request.getName(), request.getDescription(), request.getColour());
+    }
+
+    @Test
+    @TestSecurity(user = userIdStr, roles = "user")
+    public void testDeleteCategory() {
+        // given: an authenticated user
+        UUID userId = UUID.fromString(userIdStr);
+
+        // and: a category belonging to the user
+        Category category = Category.builder()
+            .id(UUID.randomUUID())
+            .name(randomAlphanumeric(20))
+            .description(randomAlphanumeric(20)).build();
+        when(categoryService.deleteCategory(userId, category.getId()))
+            .thenReturn(category);
+
+        // when: the category is deleted
+        given()
+            .request()
+            .pathParam("categoryId", category.getId())
+            .contentType(JSON)
+            .when()
+            .delete("/api/v1/rails/categories/{categoryId}")
+            .then()
+            .statusCode(204);
+
+        // then: the category-service is called with the authenticated user-id and category id
+        verify(categoryService).deleteCategory(userId, category.getId());
     }
 
     @Test
@@ -279,6 +491,9 @@ public class CategoryResourceTest extends TestBase {
         // given: an authenticated user
         UUID userId = UUID.fromString(userIdStr);
 
+        // and: a category group ID
+        UUID groupId = UUID.randomUUID();
+
         // and: a date range
         LocalDate fromDate = LocalDate.now().minusDays(7);
         LocalDate toDate = LocalDate.now();
@@ -291,18 +506,19 @@ public class CategoryResourceTest extends TestBase {
             TestData.mockCategoryStatistics("cat-2", 10, 456.44, 222.73,21.225),
             TestData.mockCategoryStatistics("cat-3", 6, 34.44, 82.73,177.25)
         );
-        when(categoryService.getStatistics(userId, startDate, endDate))
+        when(categoryService.getStatistics(userId, groupId, startDate, endDate))
             .thenReturn(expectedResult);
 
         // when: the statistics are requested
         TypeRef<List<CategoryStatisticsResponse>> typeRef = new TypeRef<>() {};
         Collection<CategoryStatisticsResponse> response = given()
             .request()
+            .pathParam("groupId", groupId)
             .queryParam("from-date", fromDate.toString())
             .queryParam("to-date", toDate.toString())
             .contentType(JSON)
             .when()
-            .get("/api/v1/rails/categories/statistics")
+            .get("/api/v1/rails/category-groups/{groupId}/statistics")
             .then()
             .statusCode(200)
             .contentType(JSON)
@@ -310,7 +526,7 @@ public class CategoryResourceTest extends TestBase {
             .as(typeRef);
 
         // then: the request is passed to the service
-        verify(categoryService).getStatistics(userId, startDate, endDate);
+        verify(categoryService).getStatistics(userId, groupId, startDate, endDate);
 
         // and: the result is as expected
         assertEquals(expectedResult.size(), response.size());
@@ -328,19 +544,41 @@ public class CategoryResourceTest extends TestBase {
         });
     }
 
-    private List<Category> mockCategories(int size) {
+    private List<CategoryGroup> mockCategoryGroups(UUID userId, int size) {
         return IntStream.range(0, size)
-            .mapToObj(i -> mockCategory(randomAlphanumeric(20)))
+            .mapToObj(i -> mockCategoryGroup(userId, randomAlphanumeric(20)))
             .toList();
     }
 
-    private Category mockCategory(String name) {
-        return Category.builder()
+    private List<Category> mockCategories(CategoryGroup group, int size) {
+        return IntStream.range(0, size)
+            .mapToObj(i -> mockCategory(group, randomAlphanumeric(20)))
+            .toList();
+    }
+
+    private CategoryGroup mockCategoryGroup(UUID userId, String name) {
+        CategoryGroup group = CategoryGroup.builder()
             .id(UUID.randomUUID())
+            .userId(userId)
+            .name(name)
+            .description(randomAlphanumeric(20))
+            .build();
+        when(categoryService.getCategoryGroup(userId, group.getId()))
+            .thenReturn(group);
+        return group;
+    }
+
+    private Category mockCategory(CategoryGroup group, String name) {
+        Category category = Category.builder()
+            .id(UUID.randomUUID())
+            .group(group)
             .name(name)
             .description(randomAlphanumeric(20))
             .colour(randomAlphanumeric(20))
             .build();
+        when(categoryService.getCategory(group.getUserId(), category.getId()))
+            .thenReturn(category);
+        return category;
     }
 
     private List<CategorySelector> mockCategorySelectors(int size, UUID accountId, UUID categoryId) {

--- a/rail-module/rail-service/src/test/java/com/hillayes/rail/resource/UserConsentResourceTest.java
+++ b/rail-module/rail-service/src/test/java/com/hillayes/rail/resource/UserConsentResourceTest.java
@@ -308,17 +308,18 @@ public class UserConsentResourceTest extends TestBase {
             .thenReturn(expectedConsentLink);
 
         // when: client calls the endpoint
-        URI response = given()
-            .request()
-            .contentType(JSON)
-            .when()
-            .pathParam("institutionId", institutionId)
-            .body(consentRequest)
-            .post("/api/v1/rails/consents/{institutionId}")
-            .then()
-            .statusCode(200)
-            .extract()
-            .as(URI.class);
+        URI response = URI.create(
+            given().request()
+                .contentType(JSON)
+                .when()
+                .pathParam("institutionId", institutionId)
+                .body(consentRequest)
+                .post("/api/v1/rails/consents/{institutionId}")
+                .then()
+                .statusCode(201)
+                .extract()
+                .header("Location")
+        );
 
         // then: a response is returned
         assertNotNull(response);

--- a/rail-module/rail-service/src/test/java/com/hillayes/rail/service/CategoryServiceTest.java
+++ b/rail-module/rail-service/src/test/java/com/hillayes/rail/service/CategoryServiceTest.java
@@ -1152,9 +1152,9 @@ public class CategoryServiceTest {
 
         // and: the repository is primed with data
         List<CategoryStatistics> expected = List.of(
-            TestData.mockCategoryStatistics("cat-1", 20, 123.44, 282.93,11.25),
-            TestData.mockCategoryStatistics("cat-2", 10, 456.44, 222.73,21.225),
-            TestData.mockCategoryStatistics("cat-3", 6, 34.44, 82.73,177.25)
+            TestData.mockCategoryStatistics(group, "cat-1", 20, 123.44, 282.93,11.25),
+            TestData.mockCategoryStatistics(group, "cat-2", 10, 456.44, 222.73,21.225),
+            TestData.mockCategoryStatistics(group, "cat-3", 6, 34.44, 82.73,177.25)
         );
         when(categoryGroupRepository.getStatistics(group, startDate, endDate))
             .thenReturn(expected);

--- a/rail-module/rail-service/src/test/java/com/hillayes/rail/utils/TestData.java
+++ b/rail-module/rail-service/src/test/java/com/hillayes/rail/utils/TestData.java
@@ -114,9 +114,10 @@ public class TestData {
         return builder.build();
     }
 
-    public static CategoryStatistics mockCategoryStatistics(String categoryName,
+    public static CategoryStatistics mockCategoryStatistics(CategoryGroup group,
+                                                            String categoryName,
                                                             int count, double total, double credit, double debit) {
-        return new CategoryStatistics(categoryName, UUID.randomUUID(),
+        return new CategoryStatistics(group.getId(), group.getName(), categoryName, UUID.randomUUID(),
             randomAlphanumeric(30), "#345678",
             count, BigDecimal.valueOf(total), BigDecimal.valueOf(credit), BigDecimal.valueOf(debit));
     }


### PR DESCRIPTION
Allow user to create category groups by which categories can be partitioned.
A "default" category group will be created for existing categories on DB migration.